### PR TITLE
Move stdin processing to `yield()`

### DIFF
--- a/cores/epoxy/Arduino.cpp
+++ b/cores/epoxy/Arduino.cpp
@@ -13,7 +13,7 @@
  */
 
 #include <inttypes.h>
-#include <unistd.h> // usleep()
+#include <unistd.h> // read(), STDIN_FILENO, usleep()
 #include <time.h> // clock_gettime()
 #include "Arduino.h"
 
@@ -22,6 +22,11 @@
 // -----------------------------------------------------------------------
 
 void yield() {
+  char c = '\0';
+  if (read(STDIN_FILENO, &c, 1) == 1) {
+    Serial.insertChar(c);
+  }
+
   usleep(1000); // prevents program from consuming 100% CPU
 }
 

--- a/cores/epoxy/main.cpp
+++ b/cores/epoxy/main.cpp
@@ -22,7 +22,7 @@
 #include <signal.h> // SIGINT
 #include <stdlib.h> // exit()
 #include <stdio.h> // perror()
-#include <unistd.h> // read()
+#include <unistd.h> // isatty(), STDIN_FILENO
 #include <fcntl.h>
 #include <termios.h>
 
@@ -113,9 +113,6 @@ int unixhostduino_main(int /*argc*/, char** /*argv*/) {
 
   setup();
   while (true) {
-    char c = '\0';
-    read(STDIN_FILENO, &c, 1);
-    if (c) Serial.insertChar(c);
     loop();
     yield();
   }


### PR DESCRIPTION
Before this patch, stdin is only read between calls to `loop()`. This causes problems when a program waits for serial input while calling `yield()` in a loop. Moving the stdin handling code to `yield()` fixes this problem and more closely matches real hardware behavior.

Also, this patch checks the return value from `read()`, which fixes a compiler warning and allows null bytes to be read correctly.