### PR TITLE
merge v1.0.0 into master

### DIFF
--- a/.github/workflows/aunit_tests.yml
+++ b/.github/workflows/aunit_tests.yml
@@ -26,5 +26,7 @@ jobs:
 
     - name: Verify tests
       run: |
+        make -C tests tests
+        make -C tests runtests
         make -C libraries tests
         make -C libraries runtests

--- a/.github/workflows/aunit_tests.yml
+++ b/.github/workflows/aunit_tests.yml
@@ -26,7 +26,11 @@ jobs:
 
     - name: Verify tests
       run: |
+        # tests/IPAddressTest requires EPOXY_CORE_ESP8266, which requires clean
+        make -C tests clean
         make -C tests tests
         make -C tests runtests
+        # clean after tests/IPAddressTest to revert to EPOXY_CORE_AVR
+        make -C libraries clean
         make -C libraries tests
         make -C libraries runtests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 1.0 (2021-09-30)
     * Add `epoxy_argc` and `epoxy_argv` as extern global variables which
       are set to the `argc` and `argv` parameters passed into the global
       `main()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
     * Add `toString()` to `IPAddress` class, activated with `EPOXY_CORE_ESP8266`
       for compatibility with ESP8266 Core.
     * Add `strstr_P()` to `pgmspace.h`.
+    * Finally fix [Issue #2](https://github.com/bxparks/EpoxyDuino/issues/2) and
+      [Issue #25](https://github.com/bxparks/EpoxyDuino/issues/25).
 * 0.8 (2021-08-08)
     * Add `EpoxyMockTimerOne` mock library for `TimerOne`
       (https://github.com/PaulStoffregen/TimerOne).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 * Unreleased
+    * Add `epoxy_argc` and `epoxy_argv` as extern global variables which
+      are set to the `argc` and `argv` parameters passed into the global
+      `main()`.
+        * Allows command line arguments to be passed into an Arduino
+          application, to facilitate debugging on a Unix desktop machine.
 * 0.8 (2021-08-08)
     * Add `EpoxyMockTimerOne` mock library for `TimerOne`
       (https://github.com/PaulStoffregen/TimerOne).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
       `main()`.
         * Allows command line arguments to be passed into an Arduino
           application, to facilitate debugging on a Unix desktop machine.
+        * Add `examples/CommandLine` which provides a basic command line parser
+          that can be copied and modified for other applications.
     * Add `toString()` to `IPAddress` class, activated with `EPOXY_CORE_ESP8266`
       for compatibility with ESP8266 Core.
     * Add `strstr_P()` to `pgmspace.h`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
       `main()`.
         * Allows command line arguments to be passed into an Arduino
           application, to facilitate debugging on a Unix desktop machine.
+    * Add `toString()` to `IPAddress` class, activated with `EPOXY_CORE_ESP8266`
+      for compatibility with ESP8266 Core.
 * 0.8 (2021-08-08)
     * Add `EpoxyMockTimerOne` mock library for `TimerOne`
       (https://github.com/PaulStoffregen/TimerOne).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
           application, to facilitate debugging on a Unix desktop machine.
     * Add `toString()` to `IPAddress` class, activated with `EPOXY_CORE_ESP8266`
       for compatibility with ESP8266 Core.
+    * Add `strstr_P()` to `pgmspace.h`.
 * 0.8 (2021-08-08)
     * Add `EpoxyMockTimerOne` mock library for `TimerOne`
       (https://github.com/PaulStoffregen/TimerOne).

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,15 @@
 # Users of this library will use 'EpoxyDuino.mk' instead.
 
 all:
+	$(MAKE) -C tests
 	$(MAKE) -C libraries
 	$(MAKE) -C examples
 
+runtests:
+	$(MAKE) -C tests runtests
+	$(MAKE) -C libraries runtests
+
 clean:
+	$(MAKE) -C tests clean
 	$(MAKE) -C libraries clean
 	$(MAKE) -C examples clean

--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ The following functions and features of the Arduino framework are implemented:
     * `pgm_read_byte()`, `pgm_read_word()`, `pgm_read_dword()`,
       `pgm_read_float()`, `pgm_read_ptr()`
     * `strlen_P()`, `strcat_P()`, `strcpy_P()`, `strncpy_P()`, `strcmp_P()`,
-      `strncmp_P()`, `strcasecmp_P()`, `strchr_P()`, `strrchr_P()`
+      `strncmp_P()`, `strcasecmp_P()`, `strchr_P()`, `strrchr_P()`, `strstr_P()`
     * `memcpy_P()`, `vsnprintf_P()`
     * `PROGMEM`, `PGM_P`, `PGM_VOID_P`, `PSTR()`
 * `IPAddress.h`

--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 [![AUnit Tests](https://github.com/bxparks/EpoxyDuino/actions/workflows/aunit_tests.yml/badge.svg)](https://github.com/bxparks/EpoxyDuino/actions/workflows/aunit_tests.yml)
 
-**New**: [GitHub Discussions](https://github.com/bxparks/EpoxyDuino/discussions)
-for this project is now active! Let's use that for general support questions,
-and reserve the [GitHub Issues](https://github.com/bxparks/EpoxyDuino/issues)
-section for bugs and feature requests.
-
 This project contains a small (but often effective) implementation of the
 Arduino programming framework for Linux, MacOS, FreeBSD (experimental) and
 potentially other POSIX-like systems. Originally, it was created to allow
@@ -513,8 +508,12 @@ Core. EpoxyDuino provides the ability substitute a different Arduino API Core
 through 2 Makefile variables:
 
 * `EPOXY_CORE`
-    * This Makefile variable defines the C-preprocessor macro which will be
-      defined through the `-D` flag through `-D $(EPOXY_CORE)`.
+* `EPOXY_CORE_PATH`
+
+#### `EPOXY_CORE`
+
+The `EPOXY_CORE` Makefile variable defines the C-preprocessor macro which will
+be defined through the `-D` flag through `-D $(EPOXY_CORE)`.
 
 There are currently 2 valid options for this Makefile variable:
 
@@ -538,12 +537,12 @@ compiler, which will activate any code that is guarded by:
 #endif
 ```
 
+#### `EPOXY_CORE_PATH`
+
 If the `EPOXY_CORE` make variable is insufficient (e.g. because the appropriate
 changes have not been incorporated into `$(EPOXY_DUINO_DIR)/cores/epoxy/`), then
-there is an even bigger hammer with the following make variable:
-
-* `EPOXY_CORE_PATH`
-    * Defines the full-path to the Arduino Core API files.
+the `EPOXY_CORE_PATH` provides an even bigger hammer. It defines the the
+full-path to the Arduino Core API files.
 
 By default, this is set to `$(EPOXY_DUINO_DIR)/cores/epoxy`. You can create your
 own set of Arduino API files in a directory of your choosing, and set this

--- a/README.md
+++ b/README.md
@@ -55,15 +55,9 @@ The disadvantages are:
   environments (e.g. 16-bit `int` versus 32-bit `int`, or 32-bit `long` versus
   64-bit `long`).
 
-**Version**: 0.8 (2021-08-08)
+**Version**: 1.0 (2021-09-30)
 
 **Changelog**: See [CHANGELOG.md](CHANGELOG.md)
-
-**Breaking Change**: Prior to v0.5, this project was known as "UnixHostDuino".
-The old `UNIX_HOST_DUINO` macro and `UnixHostDuino.mk` include file still exist
-for backwards compatibility. See
-[Issue #15](https://github.com/bxparks/EpoxyDuino/issues/15)
-for more details.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -854,19 +854,7 @@ This library has been tested on:
 <a name="Bugs"></a>
 ## Bugs and Limitations
 
-If the executable (e.g. `SampleTest.out`) is piped to the `less(1)` or `more(1)`
-command, sometimes (not all the time) the executable hangs and displays nothing
-on the pager program. I don't know why, it probably has to do with the way that
-the `less` or `more` programs manipulate the `stdin`. The solution is to
-explicitly redirect the `stdin`:
-
-```
-$ ./SampleTest.out | grep failed # works
-
-$ ./SampleTest.out | less # hangs
-
-$ ./SampleTest.out < /dev/null | less # works
-```
+None that I am aware of.
 
 <a name="FeedbackAndSupport"></a>
 ## Feedback and Support

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ for more details.
     * [Additional Clean Up](#AdditionalCleanUp)
     * [Alternate Arduino Core](#AlternateArduinoCore)
     * [PlatformIO](#PlatformIO)
+    * [Command Line Flags and Arguments](#CommandLineFlagsAndArguments)
 * [Supported Arduino Features](#SupportedArduinoFeatures)
     * [Arduino Functions](#ArduinoFunctions)
     * [Serial Port Emulation](#SerialPortEmulation)
@@ -315,9 +316,9 @@ FooLibrary
 |-- library.properties
 |-- src
 |   |-- FooLibrary.h
-|   |-- foolib
-|   |   |-- file.h
-|   |   `-- file.cpp
+|   `-- foolib
+|       |-- file.h
+|       `-- file.cpp
 `-- tests
     |-- AxxTest
     |   |-- AxxTest.ino
@@ -560,6 +561,50 @@ mode](https://docs.platformio.org/en/latest/platforms/native.html). It was added
 in [Issue #31](https://github.com/bxparks/EpoxyDuino/pull/31) (thanks
 https://github.com/lopsided98). However, this functionality is *unsupported*. If
 it becomes broken in the future, please send me a PR to fix it.
+
+<a name="CommandLineFlagsAndArguments"></a>
+### Command Line Flags and Arguments
+
+The standard Arduino environment does not provide command line arguments, since
+a microcontroller does not normally provide a command line environment.
+When an Arduino application is compiled Using EpoxyDuino, the Unix command line
+parameters (`argc` and `argv`) become available through 2 global variables:
+
+* `extern int epoxy_argc`
+* `extern const char* const* epoxy_argv`
+
+The [examples/CommandLine](examples/CommandLine) program contains a basic
+command line parser which can be copied and customized for different
+applications:
+
+```
+$ ./CommandLine.out --help
+Usage: ./CommandLine.out [--help|-h] [-s] [--include word] [--] [words ...]
+
+$ ./CommandLine.out one two
+arg: one
+arg: two
+
+$ ./CommandLine.out -s
+flag: -s
+
+$ ./CommandLine.out --include inc one two
+flag: --include inc
+arg: one
+arg: two
+
+$ ./CommandLine.out --include inc -- -one two
+flag: --include inc
+arg: -one
+arg: two
+
+$ ./CommandLine.out -a
+Unknonwn flag '-a'
+Usage: ./CommandLine.out [--help|-h] [-s] [--include word] [--] [words ...]
+```
+
+A more advanced example can be seen in
+[AUnit/TestRunner.cpp](https://github.com/bxparks/AUnit/blob/develop/src/aunit/TestRunner.cpp).
 
 <a name="SupportedArduinoFeatures"></a>
 ## Supported Arduino Features

--- a/README.md
+++ b/README.md
@@ -605,7 +605,8 @@ The following functions and features of the Arduino framework are implemented:
 * `Wire.h` (stub implementation)
 * `SPI.h` (stub implementation)
 
-See [Arduino.h](https://github.com/bxparks/EpoxyDuino/blob/develop/Arduino.h)
+See
+[Arduino.h](https://github.com/bxparks/EpoxyDuino/blob/develop/cores/epoxy/Arduino.h)
 for the latest list. Most of the header files included by this `Arduino.h`
 file were copied and modified from the [arduino:avr
 core](https://github.com/arduino/ArduinoCore-avr/tree/master/cores/arduino),

--- a/cores/epoxy/Arduino.h
+++ b/cores/epoxy/Arduino.h
@@ -216,6 +216,12 @@ int unixhostduino_main(int argc, char** argv);
 /** Calls unixhostduino_main() unless overriden by user */
 int main(int argc, char** argv);
 
+/** Copy of the argc parameter of main() as a global variable. */
+extern int epoxy_argc;
+
+/** Copy of the argv parameter of main() as a global variable. */
+extern const char* const* epoxy_argv;
+
 }
 
 // WMath prototypes

--- a/cores/epoxy/Arduino.h
+++ b/cores/epoxy/Arduino.h
@@ -28,6 +28,9 @@
 #include "WCharacter.h"
 #include "Print.h"
 #include "StdioSerial.h"
+#if defined(EPOXY_CORE_ESP8266)
+  #include "Esp.h"
+#endif
 
 // Used by digitalRead() and digitalWrite()
 #define HIGH 0x1

--- a/cores/epoxy/Arduino.h
+++ b/cores/epoxy/Arduino.h
@@ -14,8 +14,8 @@
 #define EPOXY_DUINO_EPOXY_ARDUINO_H
 
 // xx.yy.zz => xxyyzz (without leading 0)
-#define EPOXY_DUINO_VERSION 800
-#define EPOXY_DUINO_VERSION_STRING "0.8.0"
+#define EPOXY_DUINO_VERSION 10000
+#define EPOXY_DUINO_VERSION_STRING "1.0.0"
 
 #include <stdlib.h>
 #include <stdint.h>

--- a/cores/epoxy/Esp.h
+++ b/cores/epoxy/Esp.h
@@ -6,13 +6,6 @@
 #include <sys/time.h>
 #include "Stream.h"
 
-class _FLOAT
-{
-	public:
-		int digits;
-		float val;
-};
-
 class EspClass
 {
 	public:

--- a/cores/epoxy/Esp.h
+++ b/cores/epoxy/Esp.h
@@ -3,9 +3,8 @@
 
 #if defined(EPOXY_CORE_ESP8266)
 
-#include <Arduino.h>
-#include <Stream.h>
 #include <sys/time.h>
+#include "Stream.h"
 
 class _FLOAT
 {

--- a/cores/epoxy/IPAddress.cpp
+++ b/cores/epoxy/IPAddress.cpp
@@ -114,3 +114,21 @@ size_t IPAddress::printTo(Print& p) const
     n += p.print(_address.bytes[3], DEC);
     return n;
 }
+
+#if defined(EPOXY_CORE_ESP8266)
+String IPAddress::toString() const
+{
+    String s;
+    s.reserve(16);
+
+    s.concat(_address.bytes[0]);
+    s.concat('.');
+    s.concat(_address.bytes[1]);
+    s.concat('.');
+    s.concat(_address.bytes[2]);
+    s.concat('.');
+    s.concat(_address.bytes[3]);
+
+    return s;
+}
+#endif

--- a/cores/epoxy/IPAddress.cpp
+++ b/cores/epoxy/IPAddress.cpp
@@ -132,3 +132,5 @@ String IPAddress::toString() const
     return s;
 }
 #endif
+
+const IPAddress INADDR_NONE(0,0,0,0);

--- a/cores/epoxy/IPAddress.h
+++ b/cores/epoxy/IPAddress.h
@@ -67,6 +67,10 @@ public:
     IPAddress& operator=(uint32_t address);
 
     virtual size_t printTo(Print& p) const;
+
+  #if defined(EPOXY_CORE_ESP8266)
+    String toString() const;
+  #endif
 };
 
 const IPAddress INADDR_NONE(0,0,0,0);

--- a/cores/epoxy/IPAddress.h
+++ b/cores/epoxy/IPAddress.h
@@ -5,6 +5,8 @@
   Copied from Arduino AVR core 1.8.3 by Erik Tideman. Removed
   unnecessary 'friend' declarations.
 
+  Merged selected features from ESP8266 Core 2.7.4 by Brian T. Park.
+
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
@@ -32,8 +34,8 @@
 class IPAddress : public Printable {
 private:
     union {
-	uint8_t bytes[4];  // IPv4 address
-	uint32_t dword;
+      uint8_t bytes[4];  // IPv4 address
+      uint32_t dword;
     } _address;
 
     // Access the raw byte array containing the address.  Because this returns a pointer
@@ -73,6 +75,6 @@ public:
   #endif
 };
 
-const IPAddress INADDR_NONE(0,0,0,0);
+extern const IPAddress INADDR_NONE;
 
 #endif

--- a/cores/epoxy/main.cpp
+++ b/cores/epoxy/main.cpp
@@ -106,7 +106,14 @@ static void handleControlC(int /*sig*/) {
 
 extern "C" {
 
-int unixhostduino_main(int /*argc*/, char** /*argv*/) {
+int epoxy_argc;
+
+const char* const* epoxy_argv;
+
+int unixhostduino_main(int argc, char** argv) {
+  epoxy_argc = argc;
+  epoxy_argv = argv;
+
   signal(SIGINT, handleControlC);
   atexit(disableRawMode);
   enableRawMode();

--- a/cores/epoxy/pgmspace.h
+++ b/cores/epoxy/pgmspace.h
@@ -36,6 +36,7 @@
 #define strcasecmp_P strcasecmp
 #define strchr_P strchr
 #define strrchr_P strrchr
+#define strstr_P strstr
 #define memcpy_P memcpy
 #define snprintf_P snprintf
 #define vsnprintf_P vsnprintf

--- a/examples/CommandLine/CommandLine.ino
+++ b/examples/CommandLine/CommandLine.ino
@@ -1,0 +1,77 @@
+/*
+MIT License
+
+Copyright (c) 2021 Brian T. Park
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+ * CommandLine: A demo of parsing command line flags and arguments using
+ * EpoxyDuino on a Unix-like environment.
+ *
+ * This program should print the following:
+ *
+ * @verbatim
+ * $ make
+ *
+ * $ ./CommandLine.out --help
+ * Usage: ./CommandLine.out [--help|-h] [-s] [--include word] [--] [words ...]
+ *
+ * $ ./CommandLine.out one two
+ * arg: one
+ * arg: two
+ *
+ * $ ./CommandLine.out -s
+ * flag: -s
+ *
+ * $ ./CommandLine.out --include inc one two
+ * flag: --include inc
+ * arg: one
+ * arg: two
+ *
+ * $ ./CommandLine.out --include inc -- -one two
+ * flag: --include inc
+ * arg: -one
+ * arg: two
+ *
+ * $ ./CommandLine.out -a
+ * Unknonwn flag '-a'
+ * Usage: ./CommandLine.out [--help|-h] [-s] [--include word] [--] [words ...]
+ *
+ * @endverbatim
+ */
+
+#include <Arduino.h>
+#include "ProcessCommandLine.h" // processCommandLine()
+
+void setup() {
+#if ! defined(EPOXY_DUINO)
+  delay(1000); // some boards reboot twice
+#endif
+  SERIAL_PORT_MONITOR.begin(115200);
+  while (!SERIAL_PORT_MONITOR); // For Leonardo/Micro
+
+#if defined(EPOXY_DUINO)
+  processCommandLine();
+  exit(0);
+#endif
+}
+
+void loop() {}

--- a/examples/CommandLine/Makefile
+++ b/examples/CommandLine/Makefile
@@ -1,0 +1,6 @@
+# See https://github.com/bxparks/EpoxyDuino for documentation about this
+# Makefile to compile and run Arduino programs natively on Linux or MacOS.
+
+APP_NAME := CommandLine
+ARDUINO_LIBS :=
+include ../../../EpoxyDuino/EpoxyDuino.mk

--- a/examples/CommandLine/ProcessCommandLine.cpp
+++ b/examples/CommandLine/ProcessCommandLine.cpp
@@ -1,0 +1,95 @@
+/*
+MIT License
+
+Copyright (c) 2021 Brian T. Park
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#if defined(EPOXY_DUINO)
+
+#include <stdio.h> // fprintf()
+#include <string.h> // strcmp()
+#include <Arduino.h> // epoxy_argc, epoxy_argv
+#include "ProcessCommandLine.h"
+
+/** Shift argument parameters to the left by one slot. */
+static void shift(int& argc, const char* const*& argv) {
+  argc--;
+  argv++;
+}
+
+/** Return true if 2 strings are equal. */
+static bool argEquals(const char* s, const char* t) {
+  return strcmp(s, t) == 0;
+}
+
+/** Print usage and exit the program with the given status code. */
+static void usageAndExit(int status) {
+  fprintf(
+    stderr,
+    "Usage: %s [--help|-h] [-s] [--include word] [--] [words ...]\n",
+    epoxy_argv[0]
+  );
+  exit(status);
+}
+
+/**
+ * Parse command line flags.
+ * Returns the index of the first argument after the flags.
+ */
+static int parseFlags(int argc, const char* const* argv) {
+  int argc_original = argc;
+  shift(argc, argv); // skip the name of the program at argv[0]
+  while (argc > 0) {
+    if (argEquals(argv[0], "--include")) {
+      shift(argc, argv);
+      if (argc == 0) usageAndExit(1);
+      fprintf(stderr, "flag: --include %s\n", argv[0]);
+    } else if (argEquals(argv[0], "-s")) {
+      fprintf(stderr, "flag: -s\n");
+    } else if (argEquals(argv[0], "--")) {
+      shift(argc, argv);
+      break;
+    } else if (argEquals(argv[0], "--help")
+        || argEquals(argv[0], "-h")) {
+      usageAndExit(0);
+      break;
+    } else if (argv[0][0] == '-') {
+      fprintf(stderr, "Unknonwn flag '%s'\n", argv[0]);
+      usageAndExit(1);
+    } else {
+      break;
+    }
+    shift(argc, argv);
+  }
+
+  return argc_original - argc;
+}
+
+void processCommandLine() {
+  int args = parseFlags(epoxy_argc, epoxy_argv);
+
+  // Process any remaining *space*-separated arguments.
+  for (int i = args; i < epoxy_argc; i++) {
+    fprintf(stderr, "arg: %s\n", epoxy_argv[i]);
+  }
+}
+
+#endif

--- a/examples/CommandLine/ProcessCommandLine.h
+++ b/examples/CommandLine/ProcessCommandLine.h
@@ -1,0 +1,34 @@
+/*
+MIT License
+
+Copyright (c) 2021 Brian T. Park
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef PARSE_COMMAND_LINE_H
+
+#if defined(EPOXY_DUINO)
+
+/** Process the command line flags and arguments. */
+void processCommandLine();
+
+#endif
+
+#endif

--- a/examples/PipeFail/PipeFail.ino
+++ b/examples/PipeFail/PipeFail.ino
@@ -18,7 +18,7 @@
 // * Ubuntu 20.04: 300-1000
 // * MacOS 10.13: ~1000
 // * FreeBSD 12: 1000-2000
-const int NUM_LINES = 2000;
+const int NUM_LINES = 100000;
 const char LINE[] = "Reproduce https://github.com/bxparks/EpoxyDuino/issues/2";
 
 void setup() {

--- a/examples/PipeFail/PipeFail.ino
+++ b/examples/PipeFail/PipeFail.ino
@@ -3,6 +3,10 @@
  * piping to a pager program like 'less' or 'more' fails if too much data is
  * written to the SERIAL_PORT_MONITOR.
  *
+ * NOTE: https://github.com/bxparks/EpoxyDuino/issues/2 and
+ * https://github.com/bxparks/EpoxyDuino/issues/25 are now fixed, but I'll keep
+ * this around just in case.
+ *
  * To run:
  *
  * $ make clean

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "EpoxyDuino",
-    "version": "0.8.0",
+    "version": "1.0.0",
     "description": "Compile and run Arduino programs natively on Linux, MacOS and FreeBSD.",
     "keywords": [
         "unit-test",

--- a/tests/IPAddressTest/IPAddressTest.ino
+++ b/tests/IPAddressTest/IPAddressTest.ino
@@ -1,12 +1,19 @@
 #line 2 "IPAddressTest"
 
 #include <Arduino.h>
-#include <IPAddress.h> // IPAddress
 #include <AUnit.h>
-#include <AceCommon.h> // PrintStr<N>)
+#include <IPAddress.h> // IPAddress
+#include <AceCommon.h> // PrintStr<N>
 
 using aunit::TestRunner;
 using ace_common::PrintStr;
+
+//---------------------------------------------------------------------------
+
+test(IPAddressTest, INADDR_NONE) {
+  IPAddress addr(0, 0, 0, 0);
+  assertTrue(addr == INADDR_NONE);
+}
 
 test(IPAddressTest, printTo) {
   IPAddress addr(127, 0, 0, 1);

--- a/tests/IPAddressTest/IPAddressTest.ino
+++ b/tests/IPAddressTest/IPAddressTest.ino
@@ -1,0 +1,43 @@
+#line 2 "IPAddressTest"
+
+#include <Arduino.h>
+#include <IPAddress.h> // IPAddress
+#include <AUnit.h>
+#include <AceCommon.h> // PrintStr<N>)
+
+using aunit::TestRunner;
+using ace_common::PrintStr;
+
+test(IPAddressTest, printTo) {
+  IPAddress addr(127, 0, 0, 1);
+
+  PrintStr<16> ps;
+  addr.printTo(ps);
+  assertEqual(ps.cstr(), F("127.0.0.1"));
+}
+
+#if defined(EPOXY_CORE_ESP8266)
+
+test(IPAddressTest, toString) {
+  IPAddress addr(127, 0, 0, 1);
+
+  String s = addr.toString();
+  assertEqual(s, F("127.0.0.1"));
+}
+
+#endif
+
+//---------------------------------------------------------------------------
+
+void setup() {
+#if ! defined(EPOXY_DUINO)
+  delay(1000); // wait to prevent garbage on SERIAL_PORT_MONITOR
+#endif
+
+  SERIAL_PORT_MONITOR.begin(115200);
+  while (!SERIAL_PORT_MONITOR); // needed for Leonardo/Micro
+}
+
+void loop() {
+  TestRunner::run();
+}

--- a/tests/IPAddressTest/Makefile
+++ b/tests/IPAddressTest/Makefile
@@ -1,0 +1,7 @@
+# See https://github.com/bxparks/EpoxyDuino for documentation about this
+# Makefile to compile and run Arduino programs natively on Linux or MacOS.
+
+APP_NAME := IPAddressTest
+ARDUINO_LIBS := AUnit AceCommon
+EPOXY_CORE := EPOXY_CORE_ESP8266
+include ../../EpoxyDuino.mk

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,20 @@
+tests:
+	set -e; \
+	for i in *Test/Makefile; do \
+		echo '==== Making:' $$(dirname $$i); \
+		$(MAKE) -C $$(dirname $$i) -j; \
+	done
+
+runtests:
+	set -e; \
+	for i in *Test/Makefile; do \
+		echo '==== Running:' $$(dirname $$i); \
+		$$(dirname $$i)/$$(dirname $$i).out; \
+	done
+
+clean:
+	set -e; \
+	for i in *Test/Makefile; do \
+		echo '==== Cleaning:' $$(dirname $$i); \
+		$(MAKE) -C $$(dirname $$i) clean; \
+	done


### PR DESCRIPTION
* 1.0 (2021-09-30)
    * Add `epoxy_argc` and `epoxy_argv` as extern global variables which
      are set to the `argc` and `argv` parameters passed into the global
      `main()`.
        * Allows command line arguments to be passed into an Arduino
          application, to facilitate debugging on a Unix desktop machine.
        * Add `examples/CommandLine` which provides a basic command line parser
          that can be copied and modified for other applications.
    * Add `toString()` to `IPAddress` class, activated with `EPOXY_CORE_ESP8266`
      for compatibility with ESP8266 Core.
    * Add `strstr_P()` to `pgmspace.h`.
    * Finally fix [Issue #2](https://github.com/bxparks/EpoxyDuino/issues/2) and
      [Issue #25](https://github.com/bxparks/EpoxyDuino/issues/25).