### PR TITLE
Support running under MINGW32

### DIFF
--- a/cores/epoxy/main.cpp
+++ b/cores/epoxy/main.cpp
@@ -15,7 +15,7 @@
  * inserts it into the Serial buffer.
  */
 
-#ifdef EPOXY_DUINO
+#if defined(EPOXY_DUINO) && __unix__
 
 #include "Arduino.h"
 #include <inttypes.h>
@@ -140,4 +140,4 @@ int main(int argc, char** argv) {
 
 }
 
-#endif // #ifdef EPOXY_DUINO
+#endif // #if defined(EPOXY_DUINO) && __unix__

--- a/libraries/EpoxyEepromAvr/src/EpoxyEepromAvr.cpp
+++ b/libraries/EpoxyEepromAvr/src/EpoxyEepromAvr.cpp
@@ -55,7 +55,7 @@ const char* EpoxyEepromAvr::getDataPath() {
 uint8_t EERef::operator*() const {
   char c = 0;
   // Ignore errors because the EEPROM API has no mechanism for dealing them.
-#ifdef _WIN32
+#ifdef __MINGW32__
   lseek(fd, index, SEEK_SET);
   read(fd, &c, 1);
 #else
@@ -66,7 +66,7 @@ uint8_t EERef::operator*() const {
 
 EERef& EERef::operator=(uint8_t in) {
   // Ignore errors because the EEPROM API has no mechanism for dealing them.
-#ifdef _WIN32
+#ifdef __MINGW32__
   lseek(fd, index, SEEK_SET);
   write(fd, &in, 1);
 #else

--- a/libraries/EpoxyEepromAvr/src/EpoxyEepromAvr.cpp
+++ b/libraries/EpoxyEepromAvr/src/EpoxyEepromAvr.cpp
@@ -53,15 +53,25 @@ const char* EpoxyEepromAvr::getDataPath() {
 }
 
 uint8_t EERef::operator*() const {
-	char c = 0;
+  char c = 0;
   // Ignore errors because the EEPROM API has no mechanism for dealing them.
-	pread(fd, &c, 1, index);
+#ifdef _WIN32
+  lseek(fd, index, SEEK_SET);
+  read(fd, &c, 1);
+#else
+  pread(fd, &c, 1, index);
+#endif
   return c;
 }
 
 EERef& EERef::operator=(uint8_t in) {
   // Ignore errors because the EEPROM API has no mechanism for dealing them.
+#ifdef _WIN32
+  lseek(fd, index, SEEK_SET);
+  write(fd, &in, 1);
+#else
   pwrite(fd, &in, 1, index);
+#endif
   return  *this;
 }
 

--- a/libraries/EpoxyFS/src/EpoxyFS.cpp
+++ b/libraries/EpoxyFS/src/EpoxyFS.cpp
@@ -69,21 +69,12 @@ bool EpoxyFSImpl::begin() {
 
   // Create the root directory if it does not exist.
   struct stat rootStats;
-#ifdef _WIN32
-  int status = ::stat(fsroot_, &rootStats);
-  if (status != 0) {
-    int mkdirStatus = ::mkdir(fsroot_);
-    if (mkdirStatus != 0) return false;
-    // Check the directory again
-    status = ::stat(fsroot_, &rootStats);
-#else
   int status = ::lstat(fsroot_, &rootStats);
   if (status != 0) {
-    int mkdirStatus = ::mkdir(fsroot_, 0700);
+    int mkdirStatus = ::sys_mkdir(fsroot_, 0700);
     if (mkdirStatus != 0) return false;
     // Check the directory again
     status = ::lstat(fsroot_, &rootStats);
-#endif
     if (status != 0) return false;
   }
   if (! S_ISDIR(rootStats.st_mode)) return false;

--- a/libraries/EpoxyFS/src/EpoxyFS.cpp
+++ b/libraries/EpoxyFS/src/EpoxyFS.cpp
@@ -69,12 +69,21 @@ bool EpoxyFSImpl::begin() {
 
   // Create the root directory if it does not exist.
   struct stat rootStats;
+#ifdef _WIN32
+  int status = ::stat(fsroot_, &rootStats);
+  if (status != 0) {
+    int mkdirStatus = ::mkdir(fsroot_);
+    if (mkdirStatus != 0) return false;
+    // Check the directory again
+    status = ::stat(fsroot_, &rootStats);
+#else
   int status = ::lstat(fsroot_, &rootStats);
   if (status != 0) {
     int mkdirStatus = ::mkdir(fsroot_, 0700);
     if (mkdirStatus != 0) return false;
     // Check the directory again
     status = ::lstat(fsroot_, &rootStats);
+#endif
     if (status != 0) return false;
   }
   if (! S_ISDIR(rootStats.st_mode)) return false;

--- a/libraries/EpoxyFS/src/EpoxyFS.h
+++ b/libraries/EpoxyFS/src/EpoxyFS.h
@@ -195,7 +195,7 @@ class EpoxyDirImpl: public DirImpl {
 #ifdef _DIRENT_HAVE_D_TYPE
       return dirEntry_->d_type == DT_REG;
 #else
-      return (dirEntry_) ? S_ISREG(stat_.st_mode) : true;
+      return (dirEntry_) ? S_ISREG(stat_.st_mode) : false;
 #endif
     }
 


### PR DESCRIPTION
Differences in mkdir() arguments, lstat() vs stat(),
absence of dirent d_type field.

Resolves #41 