### PR TITLE
Terminal I/O enhanced (see #43)

### DIFF
--- a/cores/epoxy/Arduino.cpp
+++ b/cores/epoxy/Arduino.cpp
@@ -22,11 +22,6 @@
 // -----------------------------------------------------------------------
 
 void yield() {
-  char c = '\0';
-  if (read(STDIN_FILENO, &c, 1) == 1) {
-    Serial.insertChar(c);
-  }
-
   usleep(1000); // prevents program from consuming 100% CPU
 }
 

--- a/cores/epoxy/StdioSerial.cpp
+++ b/cores/epoxy/StdioSerial.cpp
@@ -4,15 +4,35 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 #include "StdioSerial.h"
 
 size_t StdioSerial::write(uint8_t c) {
   int result = putchar(c);
+  fflush(stdout);
   return (result == EOF) ? 0 : 1;
 }
 
 void StdioSerial::flush() {
   fflush(stdout);
+}
+
+int StdioSerial::read() {
+  int res;
+  if (bufch == -1) ::read(STDIN_FILENO, &bufch, 1);
+  res = bufch;
+  bufch = -1;
+  return res;
+}
+
+int StdioSerial::peek() {
+  if (bufch == -1) ::read(STDIN_FILENO, &bufch, 1);
+  return bufch;
+}
+
+int StdioSerial::available() {
+  if (bufch == -1) ::read(STDIN_FILENO, &bufch, 1);
+  return (bufch != -1);
 }
 
 StdioSerial Serial;

--- a/cores/epoxy/StdioSerial.h
+++ b/cores/epoxy/StdioSerial.h
@@ -15,7 +15,7 @@
  */
 class StdioSerial: public Stream {
   public:
-    void begin(unsigned long /*baud*/) { }
+    void begin(unsigned long /*baud*/) { bufch = -1; }
 
     size_t write(uint8_t c) override;
 
@@ -23,42 +23,15 @@ class StdioSerial: public Stream {
 
     operator bool() { return true; }
 
-    int available() override { return mHead != mTail; }
+    int available() override;
 
-    int read() override {
-      if (mHead == mTail) {
-        return -1;
-      } else {
-        char c = mBuffer[mHead];
-        mHead = (mHead + 1) % kBufSize;
-        return c;
-      }
-    }
+    int read() override;
+	
+    int peek() override;
 
-    int peek() override {
-      return (mHead != mTail) ? mBuffer[mHead] : -1;
-    }
-
-    /** Insert a character into the ring buffer. */
-    void insertChar(char c) {
-      int newTail = (mTail + 1) % kBufSize;
-      if (newTail == mHead) {
-        // Buffer full, drop the character. (Strictly speaking, there's one
-        // remaining slot in the buffer, but we can't use it because we need to
-        // distinguish between buffer-empty and buffer-full).
-        return;
-      }
-      mBuffer[mTail] = c;
-      mTail = newTail;
-    }
-
+    
   private:
-    // Ring buffer size (should be a power of 2 for efficiency).
-    static const int kBufSize = 128;
-
-    char mBuffer[kBufSize];
-    int mHead = 0;
-    int mTail = 0;
+    int bufch;
 };
 
 extern StdioSerial Serial;

--- a/cores/epoxy/main.cpp
+++ b/cores/epoxy/main.cpp
@@ -87,7 +87,7 @@ static void enableRawMode() {
     raw.c_cflag |= (CS8);
 
     // Enable ISIG to allow Ctrl-C to kill the program.
-    raw.c_lflag &= ~(/*ECHO | ISIG |*/ ICANON | IEXTEN);
+    raw.c_lflag &= ~(ECHO | /*ISIG |*/ ICANON | IEXTEN);
     raw.c_cc[VMIN] = 0;
     raw.c_cc[VTIME] = 0;
     if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw) == -1) {

--- a/examples/echo/Makefile
+++ b/examples/echo/Makefile
@@ -1,0 +1,6 @@
+# See https://github.com/bxparks/EpoxyDuino for documentation about this
+# Makefile to compile and run Arduino programs natively on Linux or MacOS.
+
+APP_NAME := echo
+ARDUINO_LIBS :=
+include ../../../EpoxyDuino/EpoxyDuino.mk

--- a/examples/echo/echo.ino
+++ b/examples/echo/echo.ino
@@ -1,0 +1,16 @@
+#include <Arduino.h>
+
+void setup(void)
+{
+  Serial.begin(9600);
+  while (!Serial);
+  Serial.println(F("\nEcho test"));
+}
+
+void loop(void)
+{
+  while (true) {
+    if (Serial.available())
+      Serial.print((char)Serial.read());
+  }
+}


### PR DESCRIPTION
Hi,

this PR contains the following changes:

- reading from STDIN is not any longer done in yield (Arduino.h), but in StdioSerial.cpp; with that you can now always read from the terminal
- I added a fflush call in StdioSerial::write so that every output show immediately up, as it is done when running it on the MCU
- I added a new example 'echo', which demonstrates the new capabilities

Best,
Bernhard