### PR TITLE
merge v1.2.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@
         * Wire `StdioSerial::write(uint8_t)` directly to Posix `write()`,
           by-passing the `<stdio.h>` buffer. `flush()` is no longer necessary.
         * Thanks to @felias-fogg.
-    * Revert 432e304, so that `Print::writeln()` writes `\r\n` again, see
-      [Issue#45](https://github.com/bxparks/EpoxyDuino/issues/45).
+    * **Revert Breaking Change Made in v1.1.0** Revert 432e304, so that
+      `Print::writeln()` writes `\r\n` again by default.
+        * Fixes [Issue#45](https://github.com/bxparks/EpoxyDuino/issues/45).
+        * Add `Print::setLineModeNormal()` and `Print::setLineModeUnix()`
+          methods to control the line termination behavior.
+        * See [README.md#UnixLineMode](README.md#UnixLineMode) for usage info.
 * 1.1.0 (2021-12-09)
     * Add optional `DEPS` variable containing header files that the `*.ino`
       depends on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
         * Wire `StdioSerial::write(uint8_t)` directly to Posix `write()`,
           by-passing the `<stdio.h>` buffer. `flush()` is no longer necessary.
         * Thanks to @felias-fogg.
+    * Revert 432e304, so that `Print::writeln()` writes `\r\n` again, see
+      [Issue#45](https://github.com/bxparks/EpoxyDuino/issues/45).
 * 1.1.0 (2021-12-09)
     * Add optional `DEPS` variable containing header files that the `*.ino`
       depends on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 * Unreleased
+    * Simplify `StdioSerial`  class, see
+      [Issue#43](https://github.com/bxparks/EpoxyDuino/issues/43).
+        * Replace input ring buffer with a buffer of one character.
+        * Wire `StdioSerial::write(uint8_t)` directly to Posix `write()`,
+          by-passing the `<stdio.h>` buffer. `flush()` is no longer necessary.
+        * Thanks to @felias-fogg.
 * 1.1.0 (2021-12-09)
     * Add optional `DEPS` variable containing header files that the `*.ino`
       depends on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 1.2.0 (2021-12-29)
     * Simplify `StdioSerial`  class, see
       [Issue#43](https://github.com/bxparks/EpoxyDuino/issues/43).
         * Replace input ring buffer with a buffer of one character.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The disadvantages are:
   environments (e.g. 16-bit `int` versus 32-bit `int`, or 32-bit `long` versus
   64-bit `long`).
 
-**Version**: 1.1.0 (2021-12-09)
+**Version**: 1.2.0 (2021-12-09)
 
 **Changelog**: See [CHANGELOG.md](CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -783,6 +783,27 @@ void setup() {
 }
 ```
 
+Why isn't `setLineModeUnix()` simply made to be the default on EpoxyDuino?
+Because people write [AUnit](https://github.com/bxparks/AUnit) unit tests which
+they expect will pass on both the microcontroller and on EpoxyDuino:
+
+```C++
+#include <Arduino.h>
+#include <AUnit.h>
+#include <AceCommon.h> // PrintStr<N>
+...
+
+static void sayHello(Print& printer) {
+  printer.println("hello");
+}
+
+test(myTest) {
+  PrintStr<200> observed;
+  sayHello(observed);
+  assertEqual(observed.cstr(), "hello\r\n");
+}
+```
+
 <a name="LibrariesAndMocks"></a>
 ## Libraries and Mocks
 

--- a/cores/epoxy/Arduino.cpp
+++ b/cores/epoxy/Arduino.cpp
@@ -22,11 +22,6 @@
 // -----------------------------------------------------------------------
 
 void yield() {
-  char c = '\0';
-  if (read(STDIN_FILENO, &c, 1) == 1) {
-    Serial.insertChar(c);
-  }
-
   usleep(1000); // prevents program from consuming 100% CPU
 }
 

--- a/cores/epoxy/Arduino.cpp
+++ b/cores/epoxy/Arduino.cpp
@@ -13,7 +13,7 @@
  */
 
 #include <inttypes.h>
-#include <unistd.h> // read(), STDIN_FILENO, usleep()
+#include <unistd.h> // usleep()
 #include <time.h> // clock_gettime()
 #include "Arduino.h"
 

--- a/cores/epoxy/Arduino.h
+++ b/cores/epoxy/Arduino.h
@@ -14,8 +14,8 @@
 #define EPOXY_DUINO_EPOXY_ARDUINO_H
 
 // xx.yy.zz => xxyyzz (without leading 0)
-#define EPOXY_DUINO_VERSION 10100
-#define EPOXY_DUINO_VERSION_STRING "1.1.0"
+#define EPOXY_DUINO_VERSION 10200
+#define EPOXY_DUINO_VERSION_STRING "1.2.0"
 
 #include <algorithm> // min(), max()
 #include <cmath> // abs()

--- a/cores/epoxy/Print.cpp
+++ b/cores/epoxy/Print.cpp
@@ -129,7 +129,11 @@ size_t Print::print(const Printable& x)
 
 size_t Print::println(void)
 {
-  return write("\r\n");
+  if (isLineModeUnix) {
+    return write('\n');
+  } else {
+    return write("\r\n");
+  }
 }
 
 size_t Print::println(const String &s)

--- a/cores/epoxy/Print.cpp
+++ b/cores/epoxy/Print.cpp
@@ -129,7 +129,7 @@ size_t Print::print(const Printable& x)
 
 size_t Print::println(void)
 {
-  return write('\n');
+  return write("\r\n");
 }
 
 size_t Print::println(const String &s)

--- a/cores/epoxy/Print.h
+++ b/cores/epoxy/Print.h
@@ -40,11 +40,27 @@ class Print
 {
   private:
     int write_error;
+    bool isLineModeUnix = false;
+
     size_t printNumber(unsigned long, uint8_t);
     size_t printFloat(double, uint8_t);
+
   protected:
     void setWriteError(int err = 1) { write_error = err; }
+
   public:
+    /**
+     * Set the line termination mode to Normal (i.e. \\r\\n). This is the
+     * default. This function is available only on EpoxyDuino.
+     */
+    void setLineModeNormal() { isLineModeUnix = false; }
+
+    /**
+     * Set the line termination mode to Unix (i.e. \\n). This function is
+     * available only on EpoxyDuino.
+     */
+    void setLineModeUnix() { isLineModeUnix = true; }
+
     Print() : write_error(0) {}
 
     int getWriteError() { return write_error; }

--- a/cores/epoxy/StdioSerial.cpp
+++ b/cores/epoxy/StdioSerial.cpp
@@ -4,15 +4,35 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 #include "StdioSerial.h"
 
 size_t StdioSerial::write(uint8_t c) {
   int result = putchar(c);
+  fflush(stdout);
   return (result == EOF) ? 0 : 1;
 }
 
 void StdioSerial::flush() {
   fflush(stdout);
+}
+
+int StdioSerial::read() {
+  int res;
+  if (bufch == -1) ::read(STDIN_FILENO, &bufch, 1);
+  res = bufch;
+  bufch = -1;
+  return res;
+}
+
+int StdioSerial::peek() {
+  if (bufch == -1) ::read(STDIN_FILENO, &bufch, 1);
+  return bufch;
+}
+
+int StdioSerial::available() {
+  if (bufch == -1) ::read(STDIN_FILENO, &bufch, 1);
+  return (bufch != -1);
 }
 
 StdioSerial Serial;

--- a/cores/epoxy/StdioSerial.h
+++ b/cores/epoxy/StdioSerial.h
@@ -19,8 +19,6 @@ class StdioSerial: public Stream {
 
     size_t write(uint8_t c) override;
 
-    void flush() override;
-
     operator bool() { return true; }
 
     int available() override;
@@ -28,7 +26,6 @@ class StdioSerial: public Stream {
     int read() override;
 	
     int peek() override;
-
     
   private:
     int bufch;

--- a/cores/epoxy/StdioSerial.h
+++ b/cores/epoxy/StdioSerial.h
@@ -15,7 +15,7 @@
  */
 class StdioSerial: public Stream {
   public:
-    void begin(unsigned long /*baud*/) { }
+    void begin(unsigned long /*baud*/) { bufch = -1; }
 
     size_t write(uint8_t c) override;
 
@@ -23,42 +23,15 @@ class StdioSerial: public Stream {
 
     operator bool() { return true; }
 
-    int available() override { return mHead != mTail; }
+    int available() override;
 
-    int read() override {
-      if (mHead == mTail) {
-        return -1;
-      } else {
-        char c = mBuffer[mHead];
-        mHead = (mHead + 1) % kBufSize;
-        return c;
-      }
-    }
+    int read() override;
+	
+    int peek() override;
 
-    int peek() override {
-      return (mHead != mTail) ? mBuffer[mHead] : -1;
-    }
-
-    /** Insert a character into the ring buffer. */
-    void insertChar(char c) {
-      int newTail = (mTail + 1) % kBufSize;
-      if (newTail == mHead) {
-        // Buffer full, drop the character. (Strictly speaking, there's one
-        // remaining slot in the buffer, but we can't use it because we need to
-        // distinguish between buffer-empty and buffer-full).
-        return;
-      }
-      mBuffer[mTail] = c;
-      mTail = newTail;
-    }
-
+    
   private:
-    // Ring buffer size (should be a power of 2 for efficiency).
-    static const int kBufSize = 128;
-
-    char mBuffer[kBufSize];
-    int mHead = 0;
-    int mTail = 0;
+    int bufch;
 };
 
 extern StdioSerial Serial;

--- a/cores/epoxy/main.cpp
+++ b/cores/epoxy/main.cpp
@@ -87,7 +87,7 @@ static void enableRawMode() {
     raw.c_cflag |= (CS8);
 
     // Enable ISIG to allow Ctrl-C to kill the program.
-    raw.c_lflag &= ~(/*ECHO | ISIG |*/ ICANON | IEXTEN);
+    raw.c_lflag &= ~(ECHO | /*ISIG |*/ ICANON | IEXTEN);
     raw.c_cc[VMIN] = 0;
     raw.c_cc[VTIME] = 0;
     if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw) == -1) {

--- a/examples/echo/Makefile
+++ b/examples/echo/Makefile
@@ -1,0 +1,6 @@
+# See https://github.com/bxparks/EpoxyDuino for documentation about this
+# Makefile to compile and run Arduino programs natively on Linux or MacOS.
+
+APP_NAME := echo
+ARDUINO_LIBS :=
+include ../../../EpoxyDuino/EpoxyDuino.mk

--- a/examples/echo/echo.ino
+++ b/examples/echo/echo.ino
@@ -1,0 +1,16 @@
+#include <Arduino.h>
+
+void setup(void)
+{
+  Serial.begin(9600);
+  while (!Serial);
+  Serial.println(F("\nEcho test"));
+}
+
+void loop(void)
+{
+  while (true) {
+    if (Serial.available())
+      Serial.print((char)Serial.read());
+  }
+}

--- a/examples/echo/echo.ino
+++ b/examples/echo/echo.ino
@@ -40,19 +40,20 @@
  * Serial port without interfering with the -1 error indicator.
  */
 void debugPrint(int c) {
-  // Print 2 digit hex padded with 0.
-  if (c < 16) {
-    Serial.print('0');
+  if (c < 0) {
+    // This should never happen, but print the value of c if it does.
+    Serial.print(c);
+  } else {
+    // Print 2 digit hex padded with 0.
+    if (c < 16) {
+      Serial.print('0');
+    }
+    Serial.print(c, 16);
   }
-  Serial.print(c, 16);
 
   // Print printable character, or space for non-printable.
   Serial.print("('");
-  if (c > 32 && c < 127) {
-    Serial.print((char) c);
-  } else {
-    Serial.print(' ');
-  }
+  Serial.print((c > 32 && c < 127) ? (char) c : ' ');
   Serial.print("')");
 }
 

--- a/examples/echo/echo.ino
+++ b/examples/echo/echo.ino
@@ -1,16 +1,106 @@
+/*
+ * Test reading and writing from stdin and stdout, using the keyboard or pipes.
+ *
+ * Usage:
+ *
+ * To test keyboard input:
+ *    $ ./echo.out
+ *    Echo test
+ *    'char' is signed.
+ *    # Type 'a', 'b', 'c, 'd' on keyboad
+ *    61('a')62('b')63('c')64('d')
+ *
+ * To test reading of 0xFF character (which should not interfere with -1 error):
+ *    $ printf '\xff' | ./echo.out
+ *    Echo test
+ *    'char' is signed.
+ *    FF(' ')
+ *
+ * To test reading from a directory, which generates a -1 error status when
+ * ::read() is called:
+ *    $ ./echo.out < .
+ *    Echo test
+ *    'char' is signed.
+ *    # Nothing should print.
+ *
+ * To test piping:
+ *    $ yes | ./echo.out
+ *    Echo test
+ *    'char' is signed.
+ *    79('y')0A(' ')79('y')0A(' ')[...]
+ */
+
 #include <Arduino.h>
 
-void setup(void)
-{
-  Serial.begin(9600);
-  while (!Serial);
-  Serial.println(F("\nEcho test"));
+/**
+ * Print the hexadecimal value of the character. If the character is printable
+ * in ASCII, print its character inside parenthesis. Print a space for
+ * non-printable character. Example, "61('a')" if the 'a' is passed as the
+ * argument. This is useful for determining if an 0xFF byte can be read from the
+ * Serial port without interfering with the -1 error indicator.
+ */
+void debugPrint(int c) {
+  // Print 2 digit hex padded with 0.
+  if (c < 16) {
+    Serial.print('0');
+  }
+  Serial.print(c, 16);
+
+  // Print printable character, or space for non-printable.
+  Serial.print("('");
+  if (c > 32 && c < 127) {
+    Serial.print((char) c);
+  } else {
+    Serial.print(' ');
+  }
+  Serial.print("')");
 }
 
-void loop(void)
-{
+/** Read the Serial port using an explicit while-loop. */
+void loopExplicitly() {
   while (true) {
-    if (Serial.available())
-      Serial.print((char)Serial.read());
+    if (Serial.available()) {
+      int c = Serial.read();
+      debugPrint(c);
+    }
   }
+}
+
+/**
+ * Read the Serial port using the implicit Arduino loop(), with a non-blocking
+ * one second delay to test the buffering of the keyboard input.
+ */
+void loopImplicitly() {
+  static uint16_t prevMillis = 0;
+
+  uint16_t nowMillis = millis();
+  if ((uint16_t) (nowMillis - prevMillis) > 1000) {
+    prevMillis = nowMillis;
+    if (Serial.available()) {
+      int c = Serial.read();
+      debugPrint(c);
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void setup(void) {
+  delay(1000);
+  Serial.begin(115200);
+  while (!Serial);
+
+  // Check if 'char' is a signed or unsigned on this system.
+  Serial.println(F("Echo test"));
+  char c = (char) 128;
+  int i = c;
+  if (i < 0) {
+    Serial.println(F("'char' is signed."));
+  } else {
+    Serial.println(F("'char' is unsigned."));
+  }
+}
+
+void loop(void) {
+  loopExplicitly();
 }

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "EpoxyDuino",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Compile and run Arduino programs natively on Linux, MacOS and FreeBSD.",
     "keywords": [
         "unit-test",


### PR DESCRIPTION
* 1.2.0 (2021-12-29)
    * Simplify `StdioSerial`  class, see
      [Issue#43](https://github.com/bxparks/EpoxyDuino/issues/43).
        * Replace input ring buffer with a buffer of one character.
        * Wire `StdioSerial::write(uint8_t)` directly to Posix `write()`,
          by-passing the `<stdio.h>` buffer. `flush()` is no longer necessary.
        * Thanks to @felias-fogg.
    * **Revert Breaking Change Made in v1.1.0** Revert 432e304, so that
      `Print::writeln()` writes `\r\n` again by default.
        * Fixes [Issue#45](https://github.com/bxparks/EpoxyDuino/issues/45).
        * Add `Print::setLineModeNormal()` and `Print::setLineModeUnix()`
          methods to control the line termination behavior.
        * See [README.md#UnixLineMode](README.md#UnixLineMode) for usage info.
