### PR TITLE
merge v1.2.2 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 1.2.2 (2022-02-02)
     * Add a `using Print::write` statement in `StdioSerial.h` to
       pull in all other overloaded `write()` methods from the parent `Print`
       class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 * Unreleased
+    * Add a `using Print::write` statement in `StdioSerial.h` to
+      pull in all other overloaded `write()` methods from the parent `Print`
+      class.
 * 1.2.1 (2022-01-10)
     * Add `strncasecmp_P()` to `pgmspace.h`. See
       [PR#52](https://github.com/bxparks/EpoxyDuino/pull/52).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * 1.2.1 (2022-01-10)
     * Add `strncasecmp_P()` to `pgmspace.h`. See
       [PR#52](https://github.com/bxparks/EpoxyDuino/pull/52).
-    * Add [Bugs and Limitations](README.md##BugsAndLimitations) section in
+    * Add [Bugs and Limitations](README.md#BugsAndLimitations) section in
       README.md
     * Add comment in [aunit_tests.yml](.github/workflows/aunit_tests.yml)
       that a `pull_request` event may be useful. Upgrade GitHub docker image to

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The disadvantages are:
   environments (e.g. 16-bit `int` versus 32-bit `int`, or 32-bit `long` versus
   64-bit `long`).
 
-**Version**: 1.2.1 (2022-01-10)
+**Version**: 1.2.2 (2022-02-02)
 
 **Changelog**: See [CHANGELOG.md](CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -990,6 +990,9 @@ The following environments are Tier 2 because I do not test them often enough:
       has implemented a slightly different version of the "Arduino API".
     * EpoxyDuino does not support the idiosyncrasies of all of these
       different Arduino platforms.
+    * A few features relevant to the ESP8266 and ESP32 platforms can
+      be activated by setting `EPOXY_CORE := EPOXY_CORE_ESP8266` in the
+      `Makefile`. See [Alternate Arduino Core](#AlternateArduinoCore).
 * There is yet another version of the "Arduino API" described by
   [ArduinoCore-API](https://github.com/arduino/ArduinoCore-API).
     * Some Arduino-branded microcontrollers have been migrated to

--- a/cores/epoxy/Arduino.h
+++ b/cores/epoxy/Arduino.h
@@ -14,8 +14,8 @@
 #define EPOXY_DUINO_EPOXY_ARDUINO_H
 
 // xx.yy.zz => xxyyzz (without leading 0)
-#define EPOXY_DUINO_VERSION 10201
-#define EPOXY_DUINO_VERSION_STRING "1.2.1"
+#define EPOXY_DUINO_VERSION 10202
+#define EPOXY_DUINO_VERSION_STRING "1.2.2"
 
 #include <algorithm> // min(), max()
 #include <cmath> // abs()

--- a/cores/epoxy/Print.h
+++ b/cores/epoxy/Print.h
@@ -67,11 +67,14 @@ class Print
     void clearWriteError() { setWriteError(0); }
 
     virtual size_t write(uint8_t) = 0;
+
     size_t write(const char *str) {
       if (str == NULL) return 0;
       return write((const uint8_t *)str, strlen(str));
     }
+
     virtual size_t write(const uint8_t *buffer, size_t size);
+
     size_t write(const char *buffer, size_t size) {
       return write((const uint8_t *)buffer, size);
     }

--- a/cores/epoxy/StdioSerial.h
+++ b/cores/epoxy/StdioSerial.h
@@ -19,14 +19,23 @@ class StdioSerial: public Stream {
 
     size_t write(uint8_t c) override;
 
+    // Pull in all other overloaded versions of the write() function from the
+    // Print parent class. This is required because when we override one version
+    // of write() above, C++ performs a static binding to the write() function
+    // in the current class and doesn't bother searching the parent classes for
+    // any other overloaded function that it could bind to. (30 years of C++ and
+    // I still get shot with C++ footguns like this. I have no idea what happens
+    // if the Stream class overloaded the write() function.)
+    using Print::write;
+
     operator bool() { return true; }
 
     int available() override;
 
     int read() override;
-	
+
     int peek() override;
-    
+
   private:
     int bufch;
 };

--- a/examples/StdioSerialEcho/Makefile
+++ b/examples/StdioSerialEcho/Makefile
@@ -1,6 +1,6 @@
 # See https://github.com/bxparks/EpoxyDuino for documentation about this
 # Makefile to compile and run Arduino programs natively on Linux or MacOS.
 
-APP_NAME := echo
+APP_NAME := StdioSerialEcho
 ARDUINO_LIBS :=
 include ../../../EpoxyDuino/EpoxyDuino.mk

--- a/examples/StdioSerialEcho/StdioSerialEcho.ino
+++ b/examples/StdioSerialEcho/StdioSerialEcho.ino
@@ -4,27 +4,27 @@
  * Usage:
  *
  * To test keyboard input:
- *    $ ./echo.out
+ *    $ ./StdioSerialEcho.out
  *    Echo test
  *    'char' is signed.
  *    # Type 'a', 'b', 'c, 'd' on keyboad
  *    61('a')62('b')63('c')64('d')
  *
  * To test reading of 0xFF character (which should not interfere with -1 error):
- *    $ printf '\xff' | ./echo.out
+ *    $ printf '\xff' | ./StdioSerialEcho.out
  *    Echo test
  *    'char' is signed.
  *    FF(' ')
  *
  * To test reading from a directory, which generates a -1 error status when
  * ::read() is called:
- *    $ ./echo.out < .
+ *    $ ./StdioSerialEcho.out < .
  *    Echo test
  *    'char' is signed.
  *    # Nothing should print.
  *
  * To test piping:
- *    $ yes | ./echo.out
+ *    $ yes | ./StdioSerialEcho.out
  *    Echo test
  *    'char' is signed.
  *    79('y')0A(' ')79('y')0A(' ')[...]
@@ -87,9 +87,16 @@ void loopImplicitly() {
 //-----------------------------------------------------------------------------
 
 void setup(void) {
+#if ! defined(EPOXY_DUINO)
   delay(1000);
+#endif
+
   Serial.begin(115200);
   while (!Serial);
+
+#if defined(EPOXY_DUINO)
+  Serial.setLineModeUnix();
+#endif
 
   // Check if 'char' is a signed or unsigned on this system.
   Serial.println(F("Echo test"));

--- a/examples/StdioSerialWrite/Makefile
+++ b/examples/StdioSerialWrite/Makefile
@@ -1,0 +1,6 @@
+# See https://github.com/bxparks/EpoxyDuino for documentation about this
+# Makefile to compile and run Arduino programs natively on Linux or MacOS.
+
+APP_NAME := StdioSerialWrite
+ARDUINO_LIBS :=
+include ../../../EpoxyDuino/EpoxyDuino.mk

--- a/examples/StdioSerialWrite/StdioSerialWrite.ino
+++ b/examples/StdioSerialWrite/StdioSerialWrite.ino
@@ -1,0 +1,98 @@
+/*
+ * StdioSerialWrite makes ad-hoc calls to various print(), println(), and
+ * write() output methods in the `Serial` object to verify that they work as
+ * expected. This cannot be written as an AUnit unit test because we want to
+ * test the StdioSerial class itself, not the Print parent class.
+ * 
+ * On Linux or Mac, type:
+ *  * $ make
+ *  * $ ./StdioSerialWrite.out
+ *
+ * Should print out the following:
+ *
+ * ==== Testing print(s)
+ * print(s)
+ * ==== Testing println(s)
+ * println(s)
+ * ==== Testing print(F(s))
+ * print(F(s))
+ * ==== Testing println(F(s))
+ * println(F(s))
+ * ==== Testing write(c)
+ * w
+ * ==== Testing write(s)
+ * some string
+ * ==== Testing write(buf, n)
+ * some 
+ */
+
+#include <Arduino.h>
+
+void setup() {
+#if ! defined(EPOXY_DUINO)
+  delay(1000); // some boards reboot twice
+#endif
+
+  SERIAL_PORT_MONITOR.begin(115200); // baud ignored on EpoxyDuino
+  while (!SERIAL_PORT_MONITOR); // Wait on Leonardo/Micro, no-op on EpoxyDuino
+
+#if defined(EPOXY_DUINO)
+  SERIAL_PORT_MONITOR.setLineModeUnix();
+#endif
+
+  size_t n;
+
+  SERIAL_PORT_MONITOR.println(F("==== Testing print(s)"));
+  n = SERIAL_PORT_MONITOR.print("print(s)");
+  SERIAL_PORT_MONITOR.println();
+  if (n != 8) {
+    SERIAL_PORT_MONITOR.println("print(s) should have returned 8");
+  }
+
+  SERIAL_PORT_MONITOR.println(F("==== Testing println(s)"));
+  n = SERIAL_PORT_MONITOR.println("println(s)");
+  if (n != 11) { // 10 + newline
+    SERIAL_PORT_MONITOR.println("print(s) should have returned 11");
+  }
+
+  SERIAL_PORT_MONITOR.println(F("==== Testing print(F(s))"));
+  n = SERIAL_PORT_MONITOR.print(F("print(F(s))"));
+  SERIAL_PORT_MONITOR.println();
+  if (n != 11) {
+    SERIAL_PORT_MONITOR.println(F("print(F(s)) should have returned 11"));
+  }
+
+  SERIAL_PORT_MONITOR.println(F("==== Testing println(F(s))"));
+  n = SERIAL_PORT_MONITOR.println(F("println(F(s))"));
+  if (n != 14) { // 13 + newline
+    SERIAL_PORT_MONITOR.println(F("println(F(s)) should have returned 14"));
+  }
+
+  SERIAL_PORT_MONITOR.println(F("==== Testing write(c)"));
+  n = SERIAL_PORT_MONITOR.write('w');
+  SERIAL_PORT_MONITOR.println();
+  if (n != 1) {
+    SERIAL_PORT_MONITOR.println(F("write(c) should have returned 1"));
+  }
+
+  const char buf[] = "some string"; // strlen(buf) == 11
+  SERIAL_PORT_MONITOR.println(F("==== Testing write(s)"));
+  n = SERIAL_PORT_MONITOR.write(buf);
+  SERIAL_PORT_MONITOR.println();
+  if (n != 11) {
+    SERIAL_PORT_MONITOR.println(F("write(s) should have returned 11"));
+  }
+
+  SERIAL_PORT_MONITOR.println(F("==== Testing write(buf, n)"));
+  n = SERIAL_PORT_MONITOR.write((const uint8_t*) buf, 5);
+  SERIAL_PORT_MONITOR.println();
+  if (n != 5) {
+    SERIAL_PORT_MONITOR.println(F("write(buf, n) should have returned 5"));
+  }
+
+#if defined(EPOXY_DUINO)
+  exit(0);
+#endif
+}
+
+void loop() {}

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "EpoxyDuino",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Compile and run Arduino programs natively on Linux, MacOS and FreeBSD.",
     "keywords": [
         "unit-test",


### PR DESCRIPTION
* 1.2.2 (2022-02-02)
    * Add a `using Print::write` statement in `StdioSerial.h` to
      pull in all other overloaded `write()` methods from the parent `Print`
      class.
