### PR TITLE
merge v1.2.3 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
       static. No need to expose it publicly.
     * Add `enableTerminalEcho()` function to enable terminal echoing.
       See [Enable Terminal Echo](README.md#EnableTerminalEcho).
+    * Update examples and [EpoxyFS/README.md](libraries/EpoxyFS) to be
+      compatible with new `LittleFS` library in ESP32 >=2.0.0.
 * 1.2.2 (2022-02-02)
     * Add a `using Print::write` statement in `StdioSerial.h` to
       pull in all other overloaded `write()` methods from the parent `Print`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
         * This benchmark shows that `seek()` causes significant performance
           loss, even if the `seek()` offset is identical to the internal cursor,
           so might be expected to be optimized away.
+    * Add notes about [Debugging](README.md#Debugging) tools and options
+      under a Unix environment.
 * 1.2.2 (2022-02-02)
     * Add a `using Print::write` statement in `StdioSerial.h` to
       pull in all other overloaded `write()` methods from the parent `Print`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 1.2.3 (2022-02-24)
     * Rename `unixhostduino_main()` to `epoxyduino_main()`, and make it
       static. No need to expose it publicly.
     * Add `enableTerminalEcho()` function to enable terminal echoing.
@@ -17,7 +18,7 @@
           loss, even if the `seek()` offset is identical to the internal cursor,
           so might be expected to be optimized away.
     * Add notes about [Debugging](README.md#Debugging) tools and options
-      under a Unix environment.
+      under a Unix environment, such as Valgrind.
 * 1.2.2 (2022-02-02)
     * Add a `using Print::write` statement in `StdioSerial.h` to
       pull in all other overloaded `write()` methods from the parent `Print`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
       See [Enable Terminal Echo](README.md#EnableTerminalEcho).
     * Update examples and [EpoxyFS/README.md](libraries/EpoxyFS) to be
       compatible with new `LittleFS` library in ESP32 >=2.0.0.
+    * Add [EpoxyFS/SeekBenchmark](libraries/EpoxyFSexamples/SeekBenchmark) to
+      measure the performance loss of calling `seek()` before a `read()`.
+        * Sometimes the client-code is simpler when reading multiple records
+          if it can call `seek()` with an explicit offset before each `read()`.
+        * The alternative would be calling `read()` multiple times sequentially
+          and using its internal cursor to advance automatically.
+        * This benchmark shows that `seek()` causes significant performance
+          loss, even if the `seek()` offset is identical to the internal cursor,
+          so might be expected to be optimized away.
 * 1.2.2 (2022-02-02)
     * Add a `using Print::write` statement in `StdioSerial.h` to
       pull in all other overloaded `write()` methods from the parent `Print`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 * Unreleased
+    * Rename `unixhostduino_main()` to `epoxyduino_main()`, and make it
+      static. No need to expose it publicly.
 * 1.2.2 (2022-02-02)
     * Add a `using Print::write` statement in `StdioSerial.h` to
       pull in all other overloaded `write()` methods from the parent `Print`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Unreleased
     * Rename `unixhostduino_main()` to `epoxyduino_main()`, and make it
       static. No need to expose it publicly.
+    * Add `enableTerminalEcho()` function to enable terminal echoing.
+      See [Enable Terminal Echo](README.md#EnableTerminalEcho).
 * 1.2.2 (2022-02-02)
     * Add a `using Print::write` statement in `StdioSerial.h` to
       pull in all other overloaded `write()` methods from the parent `Print`

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ The disadvantages are:
 * [Supported Arduino Features](#SupportedArduinoFeatures)
     * [Arduino Functions](#ArduinoFunctions)
     * [Serial Port Emulation](#SerialPortEmulation)
-    * [Unix Line Mode](#UnixLineMode)
+        * [Unix Line Mode](#UnixLineMode)
+        * [Enable Terminal Echo](#EnableTerminalEcho)
 * [Libraries and Mocks](#LibrariesAndMocks)
     * [Inherently Compatible Libraries](#InherentlyCompatibleLibraries)
     * [Emulation Libraries](#EmulationLibraries)
@@ -748,7 +749,7 @@ the program. But this convenience means that the Arduino program running under
 worth the trade-off.
 
 <a name="UnixLineMode"></a>
-### Unix Line Mode
+#### Unix Line Mode
 
 (Added in v1.2.0)
 
@@ -818,6 +819,31 @@ test(myTest) {
   PrintStr<200> observed;
   sayHello(observed);
   assertEqual(observed.cstr(), "hello\r\n");
+}
+```
+
+<a name="EnableTerminalEcho"></a>
+#### Enable Terminal Echno
+
+(Added in v1.2.3)
+
+By default, the `stdin` of the terminal is set to `NOECHO` mode for consistency
+with the actual serial port of an Arduino microcontroller. However when running
+a command line utility on a Unix terminal emulator using EpoxyDuino, it is often
+useful to enable echoing so that the characters being typed are visible.
+
+To enable echoing, call the `enableTerminalEcho()` function from the global
+`setup()`:
+
+```C++
+void setup() {
+  ...
+
+#if defined(EPOXY_DUINO)
+  enableTerminalEcho();
+#endif
+
+  ...
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -422,9 +422,9 @@ These parent Makefiles can be used in Continuous Integration, as shown below.
 
 You can use EpoxyDuino to run continuous integration tests or
 validations on the [GitHub Actions](https://github.com/features/actions)
-infrastructure. The basic `ubuntu-18.04` docker image already contains the C++
-compiler and `make` binary. You don't need to install the Arduino IDE or the
-Arduino CLI. You need:
+infrastructure. The basic `ubuntu-18.04` or `ubuntu-20.04` docker image already
+contains the C++ compiler and `make` binary. You don't need to install the
+Arduino IDE or the Arduino CLI. You need:
 
 * EpoxyDuino,
 * your project that you want to test,
@@ -665,7 +665,7 @@ which are implemented:
     * `bit()`, `bitRead()`, `bitSet()`, `bitClear()`, `bitWrite()`
     * `random()`, `randomSeed()`, `map()`
     * `makeWord()`
-    * `F_CPU`, `clockCyclesPerMicrosecond(), `clockCyclesToMicroseconds(),
+    * `F_CPU`, `clockCyclesPerMicrosecond(), `clockCyclesToMicroseconds()`,
       `microsecondsToClockCycles()`
     * `HIGH`, `LOW`, `INPUT`, `OUTPUT`, `INPUT_PULLUP`
     * I2C and SPI pins: `SS`, `MOSI`, `MISO`, `SCK`, `SDA`, `SCL`
@@ -692,7 +692,7 @@ which are implemented:
     * `IPAddress` class
 * `WCharacter.h`
     * `isAlpha()`, `isAscii()`, etc.
-    * `toLowerCase(), `toUpperCase()`, etc
+    * `toLowerCase()`, `toUpperCase()`, etc
 * `Wire.h` (stub implementation)
 * `SPI.h` (stub implementation)
 
@@ -704,7 +704,7 @@ v1.8.2 or v1.8.3. A number of tweaks have been made to support slight variations
 in the API of other platforms, particularly the ESP8266 v2.7.4 and ESP32 v1.0.6
 cores.
 
-The `Print.printf()` function is an extension to the `Print` class that is
+The `Print::printf()` function is an extension to the `Print` class that is
 provided by many Arduino-compatible microcontrollers (but not the AVR
 controllers). It is implemented here for convenience. The size of the internal
 buffer is `250` characters, which can be changed by changing the
@@ -854,7 +854,8 @@ These 3 types are described in more detail below.
 ### Inherently Compatible Libraries
 
 Almost all libraries that I write will be inherently compatible with EpoxyDuino
-because EpoxyDuino is what I use to develop and test my libraries.
+because EpoxyDuino is what I use to develop and test my libraries. For example,
+the following should compile using EpoxyDuino:
 
 * AUnit (https://github.com/bxparks/AUnit)
 * AceButton (https://github.com/bxparks/AceButton)
@@ -906,7 +907,7 @@ compiles, but they do not allow us to actually verify that the library works as
 intended. This limitation may be sufficient for Continous Integration purposes.
 
 * Wire
-    * The `Wire.h` header file is provided automatically by the `<Arduino.h>`
+    * The `<Wire.h>` header file is provided automatically by the `<Arduino.h>`
       file in EpoxyDuino. No additional library needs to be added to the
       `ARDUINO_LIBS` variable in the `Makefile`.
     * It provides only mock functions of the actualy `Wire` library that
@@ -916,7 +917,7 @@ intended. This limitation may be sufficient for Continous Integration purposes.
       `Wire` is a separate (but built-in) library. In retrospect, it may have
       been better to split this file into a separate mock library.
 * SPI
-    * The `SPI.h` header file was contributed recently (see #18 and #19) and
+    * The `<SPI.h>` header file was contributed recently (see #18 and #19) and
       is included automatically by the `<Arduino.h>` file in EpoxyDuino.
     * It follows the same pattern as `Wire`, the header file provides only mock
       functions of the actual `SPI` library.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The disadvantages are:
   environments (e.g. 16-bit `int` versus 32-bit `int`, or 32-bit `long` versus
   64-bit `long`).
 
-**Version**: 1.2.2 (2022-02-02)
+**Version**: 1.2.3 (2022-02-24)
 
 **Changelog**: See [CHANGELOG.md](CHANGELOG.md)
 
@@ -674,7 +674,7 @@ Below are some things that I have found useful in my own limited experience.
 #### Valgrind
 
 I have found the [Valgrind](https://valgrind.org/docs/manual/quick-start.html)
-quite helpful in tracking down Segmentation Fault crashes. Here is a quick
+tool quite helpful in tracking down Segmentation Fault crashes. Here is a quick
 start:
 
 1. Compile your program using the `-g` flag.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The disadvantages are:
     * [Alternate Arduino Core](#AlternateArduinoCore)
     * [PlatformIO](#PlatformIO)
     * [Command Line Flags and Arguments](#CommandLineFlagsAndArguments)
+    * [Debugging](#Debugging)
+        * [Valgrind](#Valgrind)
 * [Supported Arduino Features](#SupportedArduinoFeatures)
     * [Arduino Functions](#ArduinoFunctions)
     * [Serial Port Emulation](#SerialPortEmulation)
@@ -645,6 +647,52 @@ Usage: ./CommandLine.out [--help|-h] [-s] [--include word] [--] [words ...]
 
 A more advanced example can be seen in
 [AUnit/TestRunner.cpp](https://github.com/bxparks/AUnit/blob/develop/src/aunit/TestRunner.cpp).
+
+<a name="Debugging"></a>
+### Debugging
+
+A huge benefit of compiling Arduino programs using EpoxyDuino is that all the
+debugging tools in a Unix environment become automatically available. For
+example:
+
+* External Tools
+    * [Valgrind](https://valgrind.org/docs/manual/quick-start.html)
+    * [GDB Debugger](https://www.sourceware.org/gdb/)
+* Compiler Options
+    * [Address Sanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) (ASan)
+    * [Memory Sanitizer](https://github.com/google/sanitizers/wiki/MemorySanitizer)
+      (MSan)
+    * [Undefined Behavior Sanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) (UBSan)
+
+I am not an expert on any of these sanitizers, and I have not enabled them by
+default in the `EpoxyDuino.mk` file. But you have the capability to add them to
+your `Makefile` through the `CXXFLAGS` variable.
+
+Below are some things that I have found useful in my own limited experience.
+
+<a name="Valgrind"></a>
+#### Valgrind
+
+I have found the [Valgrind](https://valgrind.org/docs/manual/quick-start.html)
+quite helpful in tracking down Segmentation Fault crashes. Here is a quick
+start:
+
+1. Compile your program using the `-g` flag.
+    * This is not strictly necessary but this will allow Valgrind to print line
+      numbers to the source code in the stack trace.
+    * Two ways:
+        * Pass the pass through the command line: `$ make CXXFLAGS=-g`
+        * Edit the `Makefile` and add a `CXXFLAGS += -g` directive
+          near the top of the file.
+2. Run the program under the `valgrind` program.
+    * Valgrind has tons of options and flags. Here are the flags that I use
+      (don't remember where I got them):
+        * `$ alias val='valgrind --tool=memcheck --leak-check=yes
+        --show-reachable=yes --num-callers=20 --track-fds=yes'`
+        * `$ val ./MyProgram.out`
+
+When the program crashes because of a `nullptr` dereference, Valgrind will show
+exactly where that happened in the source code.
 
 <a name="SupportedArduinoFeatures"></a>
 ## Supported Arduino Features

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For actual application development, I have started to build a set of
 libraries within EpoxyDuino which emulate the versions that run the actual
 hardware:
 
-* EpoxyFS: emulation of the ESP8266 LittleFS or ESP32 LITTLEFS
+* EpoxyFS: emulation of the ESP8266 LittleFS or ESP32 LittleFS
 * EpoxyEepromAvr: emulation of AVR-flavored `EEPROM`
 * EpoxyEepromEsp: emulation of ESP-flavored `EEPROM`
 
@@ -51,7 +51,7 @@ portable to a vanilla Unix environment, EpoxyDuino may work well for you.
 Running an Arduino program natively on a desktop-class machine has some
 advantages:
 
-* The development cycle can be lot faster because the compilers on the the
+* The development cycle can be lot faster because the compilers on the
   desktop machines are a lot faster, and we also avoid the upload and flash
   process to the microcontroller.
 * The desktop machine can run unit tests which require too much flash or too
@@ -259,7 +259,7 @@ provided by the Arduino IDE:
   an `#include <Arduino.h>` include line at the top of the file. This is
   compatible with the Arduino IDE which automatically includes `<Arduino.h>`.
 * The Arduino IDE supports multiple `ino` files in the same directory. (I
-  believe it simply concontenates them all into a single file.) EpoxyDuino
+  believe it simply concatenates them all into a single file.) EpoxyDuino
   supports only one `ino` file in a given directory.
 * The Arduino IDE automatically generates forward declarations for functions
   that appear *after* the global `setup()` and `loop()` methods. In a normal
@@ -581,8 +581,8 @@ compiler, which will activate any code that is guarded by:
 
 If the `EPOXY_CORE` make variable is insufficient (e.g. because the appropriate
 changes have not been incorporated into `$(EPOXY_DUINO_DIR)/cores/epoxy/`), then
-the `EPOXY_CORE_PATH` provides an even bigger hammer. It defines the the
-full-path to the Arduino Core API files.
+the `EPOXY_CORE_PATH` provides an even bigger hammer. It defines the full-path
+to the Arduino Core API files.
 
 By default, this is set to `$(EPOXY_DUINO_DIR)/cores/epoxy`. You can create your
 own set of Arduino API files in a directory of your choosing, and set this
@@ -908,7 +908,7 @@ EpoxyDuino. I have provided 3 such libraries within the EpoxyDuino project:
 * [libraries/EpoxyFS](libraries/EpoxyFS)
     * An implementation of a file system compatible with
       [ESP8266 LittleFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html)
-      and [ESP32 LITTLEFS](https://github.com/lorol/LITTLEFS).
+      and [ESP32 LitteFS](https://github.com/espressif/arduino-esp32/tree/master/libraries/LittleFS).
 * Two EEPROM implementations:
     * [libraries/EpoxyEepromAvr](libraries/EpoxyEepromAvr)
         * API compatible with
@@ -930,13 +930,13 @@ the Linux/MacOS host.
 Mock libraries are designed to run under EpoxyDuino and provide non-working API
 stubs of the target library. These libraries are useful to verify that a program
 compiles, but they do not allow us to actually verify that the library works as
-intended. This limitation may be sufficient for Continous Integration purposes.
+intended. This limitation may be sufficient for Continuous Integration purposes.
 
 * Wire
     * The `<Wire.h>` header file is provided automatically by the `<Arduino.h>`
       file in EpoxyDuino. No additional library needs to be added to the
       `ARDUINO_LIBS` variable in the `Makefile`.
-    * It provides only mock functions of the actualy `Wire` library that
+    * It provides only mock functions of the actually `Wire` library that
       is provided by real Arduino frameworks.
     * This was added very early in the development of EpoxyDuino so that I could
       compile some of my programs. I don't think I realized at the time that

--- a/cores/epoxy/Arduino.h
+++ b/cores/epoxy/Arduino.h
@@ -245,10 +245,7 @@ void setup();
 /** Provided in the client code's *.ino file. */
 void loop();
 
-/** Default entrypoint, runs setup() and loop() */
-int unixhostduino_main(int argc, char** argv);
-
-/** Calls unixhostduino_main() unless overriden by user */
+/** Calls epoxyduino_main() unless overriden by user */
 int main(int argc, char** argv);
 
 /** Copy of the argc parameter of main() as a global variable. */

--- a/cores/epoxy/Arduino.h
+++ b/cores/epoxy/Arduino.h
@@ -254,6 +254,16 @@ extern int epoxy_argc;
 /** Copy of the argv parameter of main() as a global variable. */
 extern const char* const* epoxy_argv;
 
+/**
+ * Enable echoing of each character. By default echoing is turned off for
+ * consistency with the behavior of the serial port of a real Arduino
+ * microcontroller. However when running on a Unix machine inside a terminal
+ * emulator, it is often more useful to enable echoing so that the user can see
+ * the characters being typed. This function should be called in the setup(),
+ * guarded by a `#if defined(EPOXY_DUINO)`.
+ */
+void enableTerminalEcho();
+
 }
 
 // WMath prototypes

--- a/cores/epoxy/Arduino.h
+++ b/cores/epoxy/Arduino.h
@@ -14,8 +14,8 @@
 #define EPOXY_DUINO_EPOXY_ARDUINO_H
 
 // xx.yy.zz => xxyyzz (without leading 0)
-#define EPOXY_DUINO_VERSION 10202
-#define EPOXY_DUINO_VERSION_STRING "1.2.2"
+#define EPOXY_DUINO_VERSION 10203
+#define EPOXY_DUINO_VERSION_STRING "1.2.3"
 
 #include <algorithm> // min(), max()
 #include <cmath> // abs()

--- a/cores/epoxy/main.cpp
+++ b/cores/epoxy/main.cpp
@@ -116,7 +116,7 @@ int epoxy_argc;
 
 const char* const* epoxy_argv;
 
-int unixhostduino_main(int argc, char** argv) {
+static int epoxyduino_main(int argc, char** argv) {
   epoxy_argc = argc;
   epoxy_argv = argv;
 
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
 __attribute__((weak));
 
 int main(int argc, char** argv) {
-  return unixhostduino_main(argc, argv);
+  return epoxyduino_main(argc, argv);
 }
 
 }

--- a/cores/epoxy/main.cpp
+++ b/cores/epoxy/main.cpp
@@ -130,6 +130,17 @@ static int epoxyduino_main(int argc, char** argv) {
   }
 }
 
+void enableTerminalEcho() {
+  struct termios term;
+  if (tcgetattr(STDIN_FILENO, &term) == -1) {
+    return;
+  }
+  term.c_lflag |= ECHO;
+  if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &term) == -1) {
+    return;
+  }
+}
+
 // Weak reference so that the calling code can provide its own main().
 int main(int argc, char** argv)
 __attribute__((weak));

--- a/libraries/EpoxyFS/README.md
+++ b/libraries/EpoxyFS/README.md
@@ -9,6 +9,7 @@ that runs on a POSIX-like environment (Linux, MacOS, FreeBSD) using EpoxyDuino.
 ## Table of Contents
 
 * [Usage](#Usage)
+* [Examples](#Examples)
 * [Portability](#Portability)
 * [File System Location](#FileSystemLocation)
 * [Bugs and Limitations](#BugsAndLimitations)
@@ -20,7 +21,7 @@ The `FS` class in EpoxyFS is compatible with the `FS` class on the ESP8266 and
 ESP32 platforms. There are several implementations of the `FS` class on various
 platforms:
 
-* ESP8266
+* ESP8266 v3.0.2
     * Built-in library
       [LittleFS](https://github.com/esp8266/Arduino/tree/master/libraries/LittleFS)
     * Built-in library
@@ -30,25 +31,27 @@ platforms:
     * Built-in library
       [SDFS](https://github.com/esp8266/Arduino/tree/master/libraries/SDFS)
       (never tested by me)
-* ESP32
-    * For >= 2.0.0, provides built-in library
+* ESP32 v2.0.2
+    * Built-in library
       [LittleFS](https://github.com/espressif/arduino-esp32/tree/master/libraries/LittleFS)
-      which follows the same conventions as ESP8266
-    * For < 2.0.0, requires [LITTLEFS](https://github.com/lorol/LITTLEFS) third
-      party library.
+      which follows similar (but not always the same) conventions as the ESP8266
+      LittleFS library.
     * Built-in library
       [SPIFFS](https://github.com/espressif/arduino-esp32/tree/master/libraries/SPIFFS)
       (Not sure if this is deprecated as well.)
+    * Early versions of EpoxyFS tested against the
+      [LITTLEFS](https://github.com/lorol/LITTLEFS) third party library.
+      I'm not sure if this still works.
 
 Each file system automatically creates a global instance of `FS` class for
 convenience:
 
 * `LittleFS.h` libraries create instances named `LittleFS`
 * `LITTLEFS.h` library creates an instance named `LITTLEFS`
-* `EpoxyFS.h` library creates an instance named `fs::EpoxyFS` (in the `fs`
-  namespace to reduce name collision)
 * `SPIFFS.h` libraries create instances named `SPIFFS`
 * `SDFS.h` library creates a instance named `SDFS`
+* `EpoxyFS.h` library creates an instance named `fs::EpoxyFS` (in the `fs`
+  namespace to reduce name collision)
 
 To write code that's compatible across multiple platforms, including EpoxyDuino,
 I recommend using C-preprocessor macros to to set the correct file system
@@ -84,14 +87,14 @@ void setup() {
 
   SERIAL_PORT_MONITOR.println(F("Initializing file system"));
   if (! FILE_SYSTEM.begin()){
-    SERIAL_PORT_MONITOR.println(F("Failed to init file system"));
+    SERIAL_PORT_MONITOR.println(F("Error initializing file system"));
     // handle error
   }
 
   SERIAL_PORT_MONITOR.println(F("Opening myfile.txt"));
   fs::File file = FILE_SYSTEM.open("myfile.txt", "r");
   if (! file) {
-    SERIAL_PORT_MONITOR.println(F("Failed to open myfile.txt"));
+    SERIAL_PORT_MONITOR.println(F("Error opening myfile.txt"));
     // handle error
   }
 
@@ -104,10 +107,16 @@ void loop() {
 }
 ```
 
+<a name="Examples"></a>
+## Examples
+
+* [examples/HelloEpoxyFS](examples/HelloEpoxyFS)
+    * Tested on EpoxyDuino, ESP8266 3.0.2 and ESP32 2.0.2.
+
 <a name="Portability"></a>
 ## Portability
 
-I have tested mostly against the "LittleFS" libraries.
+I have tested mostly against the "LittleFS" libraries on the ESP8266 and ESP32.
 
 In my experience, the `fs::File` class is more compatible across different
 platforms than the `fs::FS` class. So instead of passing around the `fs::FS`

--- a/libraries/EpoxyFS/README.md
+++ b/libraries/EpoxyFS/README.md
@@ -1,17 +1,61 @@
 # EpoxyFS
 
-An implementation of the `FS` filesystem interface for ESP8266
-(https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html) that runs on
-a Linux (and hopefully on a MacOS) machine using EpoxyDuino.
+An implementation of the `FS` file system interface provided
+[by ESP8266](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html)
+and
+[by ESP32](https://github.com/espressif/arduino-esp32/tree/master/libraries/FS)
+that runs on a POSIX-like environment (Linux, MacOS, FreeBSD) using EpoxyDuino.
 
+## Table of Contents
+
+* [Usage](#Usage)
+* [Portability](#Portability)
+* [File System Location](#FileSystemLocation)
+* [Bugs and Limitations](#BugsAndLimitations)
+
+<a name="Usage"></a>
 ## Usage
 
-The `FS` class in EpoxyFS is compatible with the `FS` class on the ESP8266
-platform. Unfortunately, the `FS` class under the ESP32 is slightly different.
-This means that we cannot use `FS` as a common interface across platforms.
-Instead we use a `#define FILE_SYSTEM` to set the correct file system instance,
-and use `FILE_SYSTEM` everywhere where we would have used a `LittleFS`, or
-`LITTLEFS` or `fs::EpoxyFS` instance.
+The `FS` class in EpoxyFS is compatible with the `FS` class on the ESP8266 and
+ESP32 platforms. There are several implementations of the `FS` class on various
+platforms:
+
+* ESP8266
+    * Built-in library
+      [LittleFS](https://github.com/esp8266/Arduino/tree/master/libraries/LittleFS)
+    * Built-in library
+      [SPIFFS](https://github.com/esp8266/Arduino/tree/master/cores/esp8266/spiffs)
+      which is
+      [deprecated](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-deprecation-warning)
+    * Built-in library
+      [SDFS](https://github.com/esp8266/Arduino/tree/master/libraries/SDFS)
+      (never tested by me)
+* ESP32
+    * For >= 2.0.0, provides built-in library
+      [LittleFS](https://github.com/espressif/arduino-esp32/tree/master/libraries/LittleFS)
+      which follows the same conventions as ESP8266
+    * For < 2.0.0, requires [LITTLEFS](https://github.com/lorol/LITTLEFS) third
+      party library.
+    * Built-in library
+      [SPIFFS](https://github.com/espressif/arduino-esp32/tree/master/libraries/SPIFFS)
+      (Not sure if this is deprecated as well.)
+
+Each file system automatically creates a global instance of `FS` class for
+convenience:
+
+* `LittleFS.h` libraries create instances named `LittleFS`
+* `LITTLEFS.h` library creates an instance named `LITTLEFS`
+* `EpoxyFS.h` library creates an instance named `fs::EpoxyFS` (in the `fs`
+  namespace to reduce name collision)
+* `SPIFFS.h` libraries create instances named `SPIFFS`
+* `SDFS.h` library creates a instance named `SDFS`
+
+To write code that's compatible across multiple platforms, including EpoxyDuino,
+I recommend using C-preprocessor macros to to set the correct file system
+instance. In the following code snippet, the `#define FILE_SYSTEM` is set to the
+appropriate instance of the selected file system library, and this is used in
+all places where where a direct reference to `LittleFS`, or `LITTLEFS` or
+`fs::EpoxyFS` instance would be made.
 
 ```C++
 #include <Arduino.h>
@@ -23,25 +67,35 @@ and use `FILE_SYSTEM` everywhere where we would have used a `LittleFS`, or
   #include <LittleFS.h>
   #define FILE_SYSTEM LittleFS
 #elif defined(ESP32)
-  #include <LITTLEFS.h>
-  #define FILE_SYSTEM LITTLEFS
+  #include <LittleFS.h>
+  #define FILE_SYSTEM LittleFS
 #else
   #error Unsupported platform
 #endif
 
-void doStuff() {
+void doStuff(fs::File& file) {
+  ...
 }
-  
+
 void setup() {
   SERIAL_PORT_MONITOR.begin(115200);
   while (!SERIAL_PORT_MONITOR); // For Leonardo/Micro
   ...
 
-  if (FILE_SYSTEM.begin()){
-    SERIAL_PORT_MONITOR.println(F("Filesystem initialized."));
-  } else {
-    SERIAL_PORT_MONITOR.println(F("Filesystem failed."));
+  SERIAL_PORT_MONITOR.println(F("Initializing file system"));
+  if (! FILE_SYSTEM.begin()){
+    SERIAL_PORT_MONITOR.println(F("Failed to init file system"));
+    // handle error
   }
+
+  SERIAL_PORT_MONITOR.println(F("Opening myfile.txt"));
+  fs::File file = FILE_SYSTEM.open("myfile.txt", "r");
+  if (! file) {
+    SERIAL_PORT_MONITOR.println(F("Failed to open myfile.txt"));
+    // handle error
+  }
+
+  doStuff(file);
   ...
 }
 
@@ -50,26 +104,59 @@ void loop() {
 }
 ```
 
-## Root of the File System
+<a name="Portability"></a>
+## Portability
 
-By default, the root of the file system is located in a directory named
-`./epoxyfsdata` in the *current directory*. This location can be changed by
-setting the
+I have tested mostly against the "LittleFS" libraries.
 
-* `EPOXY_FS_ROOT`
+In my experience, the `fs::File` class is more compatible across different
+platforms than the `fs::FS` class. So instead of passing around the `fs::FS`
+instance, I had better luck obtaining portable code by passing around the
+`fs::File` instance.
 
-environment variable. For example, setting
+Some documentation (I cannot find it now) says that if the name of the file does
+*not* begin with a '/' character, it is assumed to be at the root of the file
+system tree. The `EpoxyFS` library follows that convention. However, I found
+that in the most recent version of LittleFS on ESP32 v2.0.2, the '/' character
+prefix was required to find the files that was uploaded through the [universal
+LittleFS upload tool](https://github.com/lorol/arduino-esp32fs-plugin). For
+portability, it may be necessary to always prepend a '/' to convert the file
+name to an absolute path instead of a relative path .
+
+The ESP8266 version of `File` implements `File::fullName()`. The ESP32 version
+implements this as `file::path()`.
+
+The ESP32 version of `LittleFS` does not implement the `fs::Dir` class. EpoxyFS
+copied the API from ESP8266 and implements `fs::Dir`.
+
+<a name="FileSystemLocation"></a>
+## File System Location
+
+By default, the root of the `EpoxyFS` file system is located in a directory
+named `./epoxyfsdata` in the *current directory*. This location can be changed
+by setting the `EPOXY_FS_ROOT` environment variable like this:
 
 * `$ export EPOXY_FS_ROOT=/tmp/epoxyfsdata`
-
-sets the root to the `/tmp/epoxyfsdata` directory.
 
 **DANGER**: The `EpoxyFS::format()` method creates a blank file system. To
 achieve that, the method recursively removes all files and directories under the
 `EPOXY_FS_ROOT` directory. If you set the `EPOXY_FS_ROOT` to an incorrect value,
 you may remove a **lot** of files quickly and permanently. Be very careful!
 
-## Bugs and LImitation
+You can add this snippet to your `.gitignore` file
+```
+# Root directory of EpoxyFS
+epoxyfsdata
+```
+to prevent `git` from adding these files to the repo.
+
+I believe both the ESP8266 and ESP32 upload tools assume that the data files
+live in a directory called `data` in the sketch directory. I deliberately named
+`epoxyfsdata` different from `data` to prevent unintended interaction with these
+tools.
+
+<a name="BugsAndLimitations"></a>
+## Bugs and Limitations
 
 * A number of functions and methods are not yet implemented. See the `TODO`
   notes in `src/EpoxyFS.h`.

--- a/libraries/EpoxyFS/examples/HelloEpoxyFS/HelloEpoxyFS.ino
+++ b/libraries/EpoxyFS/examples/HelloEpoxyFS/HelloEpoxyFS.ino
@@ -1,3 +1,95 @@
+/*
+Test writing and reading to the filesystem using EpoxyFS on EpoxyDuino, and
+LittleFS on ESP8266 and ESP32. The expected output on various platforms is shown
+below:
+
+EpoxyDuino:
+
+```
+== Initializing EpoxyFS
+== Formatting file system
+== List '/' using fs::Dir
+== Writing /testfile.txt
+Created /testfile.txt
+== List '/' using fs::Dir
+Dir entry #1
+Dir: fileName()=testfile.txt
+isDirectory=false
+fileSize()=0
+File: name()=testfile.txt
+fullName()=/testfile.txt
+size()=31
+== Reading /testfile.txt
+name(): testfile.txt
+fullName(): /testfile.txt
+This is a test
+42
+42.00
+2A
+== Recursively remove '/' using nftw()
+File: epoxyfsdata/testfile.txt
+Post Dir: epoxyfsdata
+== List '/' using fs::Dir
+== Done
+```
+
+# ESP8266:
+
+```
+== Initializing LittleFS
+== Formatting file system
+== List '/' using fs::Dir
+== Writing /testfile.txt
+Created /testfile.txt
+== List '/' using fs::Dir
+Dir entry #1
+Dir: fileName()=testfile.txt
+isDirectory=false
+fileSize()=31
+File: name()=testfile.txt
+fullName()=testfile.txt
+size()=31
+== Reading /testfile.txt
+name(): testfile.txt
+fullName(): /testfile.txt
+This is a test
+42
+42.00
+2A
+== Recursively remove '/' not implemented
+== List '/' using fs::Dir
+Dir entry #1
+Dir: fileName()=testfile.txt
+isDirectory=false
+fileSize()=31
+File: name()=testfile.txt
+fullName()=testfile.txt
+size()=31
+== Done
+```
+
+# ESP32:
+
+```
+== Initializing LittleFS
+== Formatting file system
+== List '/' not implemented on ESP32
+== Writing /testfile.txt
+Created /testfile.txt
+== List '/' not implemented on ESP32
+== Reading /testfile.txt
+name(): testfile.txt
+path()=/testfile.txt
+This is a test
+42
+42.00
+2A
+== Recursively remove '/' not implemented
+== List '/' not implemented on ESP32
+== Done
+```
+*/
+
 #include <stdio.h> // remove()
 #include <Arduino.h>
 

--- a/libraries/EpoxyFS/examples/SeekBenchmark/Makefile
+++ b/libraries/EpoxyFS/examples/SeekBenchmark/Makefile
@@ -1,0 +1,10 @@
+# See https://github.com/bxparks/EpoxyDuino for documentation about this
+# Makefile to compile and run Arduino programs natively on Linux or MacOS.
+
+APP_NAME := SeekBenchmark
+ARDUINO_LIBS := EpoxyFS AceCommon
+MORE_CLEAN := more_clean
+include ../../../../EpoxyDuino.mk
+
+more_clean:
+	rm -rf epoxyfsdata

--- a/libraries/EpoxyFS/examples/SeekBenchmark/SeekBenchmark.ino
+++ b/libraries/EpoxyFS/examples/SeekBenchmark/SeekBenchmark.ino
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2022 Brian T. Park
+ * Commercial License
+ */
+
+/*
+Benchmark the following operations:
+
+* write()
+    * write 300 records of 100 random bytes, total 30kB
+* read()
+    * read 300 records of 100 bytes
+    * no call to seek() before reading
+* seek()/read()
+    * call seek(offset) before reading a record of 100 bytes
+    * iterate for 300 records
+    * the offset is the *current* position so in theory the library code
+      ought to be able to optimize that away, but does not
+    * called twice to reduce effect of any caching
+
+**EpoxyDuino**
+```
+BENCHMARKS
+write() 231
+seek()/read() 1279
+seek()/read() 1129
+read() 144
+END
+```
+
+**ESP8266**
+```
+BENCHMARKS
+write() 472975
+seek()/read() 32162
+seek()/read() 31921
+read() 12737
+END
+```
+
+**ESP32**
+```
+BENCHMARKS
+write() 245635
+seek()/read() 18123
+seek()/read() 18065
+read() 15041
+END
+```
+*/
+
+#include <Arduino.h>
+
+#ifndef SERIAL_PORT_MONITOR
+  #define SERIAL_PORT_MONITOR Serial
+#endif
+
+#if defined(EPOXY_DUINO)
+  #include <EpoxyFS.h>
+  #define FILE_SYSTEM fs::EpoxyFS
+#elif defined(ESP8266)
+  #include <LittleFS.h>
+  #define FILE_SYSTEM LittleFS
+#elif defined(ESP32)
+  #include <LittleFS.h>
+  #define FILE_SYSTEM LittleFS
+#else
+  #error Unsupported platform
+#endif
+
+#define TEST_FILE_NAME "/testfile.out"
+
+const uint16_t ITERATION = 300;
+const uint16_t READ_SIZE = 100;
+
+//-----------------------------------------------------------------------------
+
+// Read file with File::seek();
+void seekReadFile(const char* label, fs::File& file) {
+  file.seek(0);
+  char buffer[READ_SIZE];
+  uint16_t offset = 0;
+
+  unsigned long startMicros = micros();
+  for (uint16_t i = 0; i < ITERATION; i++) {
+    file.seek(offset);
+    file.readBytes(buffer, sizeof(buffer));
+    offset += READ_SIZE;
+  }
+  unsigned long elapsedMicros = micros() - startMicros;
+
+  SERIAL_PORT_MONITOR.print(label);
+  SERIAL_PORT_MONITOR.print(' ');
+  SERIAL_PORT_MONITOR.println(elapsedMicros);
+}
+
+// Read file without File::seek();
+void readFile(const char* label, fs::File& file) {
+  file.seek(0);
+  char buffer[READ_SIZE];
+
+  unsigned long startMicros = micros();
+  for (uint16_t i = 0; i < ITERATION; i++) {
+    file.readBytes(buffer, sizeof(buffer));
+  }
+  unsigned long elapsedMicros = micros() - startMicros;
+
+  SERIAL_PORT_MONITOR.print(label);
+  SERIAL_PORT_MONITOR.print(' ');
+  SERIAL_PORT_MONITOR.println(elapsedMicros);
+}
+
+void runBenchmarks(const char* fileName) {
+  File file = FILE_SYSTEM.open(fileName, "r");
+  if (!file) {
+    SERIAL_PORT_MONITOR.printf("Could not open '%s' for read.\n", fileName);
+    return;
+  }
+
+  seekReadFile("seek()/read()", file); // warm up any cache
+  seekReadFile("seek()/read()", file);
+  readFile("read()", file);
+
+  file.close();
+}
+
+void createFile(const char* label, const char* fileName) {
+  File file = FILE_SYSTEM.open(fileName, "w");
+  if (!file) {
+    SERIAL_PORT_MONITOR.printf("Could not open '%s' for write.\n", fileName);
+    return;
+  }
+
+  unsigned long startMicros = micros();
+  char buffer[READ_SIZE]; // no initialization, so full of random stuff
+  for (uint16_t i = 0; i < ITERATION; i++) {
+    file.write((const uint8_t*) buffer, sizeof(buffer));
+  }
+  unsigned long elapsedMicros = micros() - startMicros;
+
+  SERIAL_PORT_MONITOR.print(label);
+  SERIAL_PORT_MONITOR.print(' ');
+  SERIAL_PORT_MONITOR.println(elapsedMicros);
+  file.close();
+}
+
+//-----------------------------------------------------------------------------
+
+void setup() {
+#if ! defined(EPOXY_DUINO)
+  delay(1000); // some boards reboot twice
+#endif
+
+  SERIAL_PORT_MONITOR.begin(115200);
+  while (!SERIAL_PORT_MONITOR); // For Leonardo/Micro
+#if defined(EPOXY_DUINO)
+  SERIAL_PORT_MONITOR.setLineModeUnix();
+#endif
+
+  SERIAL_PORT_MONITOR.println(F("Initializing file system"));
+  if (! FILE_SYSTEM.begin()) {
+    SERIAL_PORT_MONITOR.println(F("Error initializing file system"));
+    exit(1);
+  }
+
+  SERIAL_PORT_MONITOR.println(F("BENCHMARKS"));
+  createFile("write()", TEST_FILE_NAME);
+  runBenchmarks(TEST_FILE_NAME);
+  SERIAL_PORT_MONITOR.println("END");
+
+#if defined(EPOXY_DUINO)
+  exit(0);
+#endif
+}
+
+void loop() {
+}

--- a/libraries/EpoxyFS/tests/EpoxyFSTest/EpoxyFSTest.ino
+++ b/libraries/EpoxyFS/tests/EpoxyFSTest/EpoxyFSTest.ino
@@ -11,8 +11,8 @@
   #include <LittleFS.h>
   #define FILE_SYSTEM LittleFS
 #elif defined(ESP32)
-  #include <LITTLEFS.h>
-  #define FILE_SYSTEM LITTLEFS
+  #include <LittleFS.h>
+  #define FILE_SYSTEM LittleFS
 #else
   #error Unsupported platform
 #endif

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "EpoxyDuino",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "Compile and run Arduino programs natively on Linux, MacOS and FreeBSD.",
     "keywords": [
         "unit-test",


### PR DESCRIPTION
* 1.2.3 (2022-02-24)
    * Rename `unixhostduino_main()` to `epoxyduino_main()`, and make it
      static. No need to expose it publicly.
    * Add `enableTerminalEcho()` function to enable terminal echoing.
      See [Enable Terminal Echo](README.md#EnableTerminalEcho).
    * Update examples and [EpoxyFS/README.md](libraries/EpoxyFS) to be
      compatible with new `LittleFS` library in ESP32 >=2.0.0.
    * Add [EpoxyFS/SeekBenchmark](libraries/EpoxyFSexamples/SeekBenchmark) to
      measure the performance loss of calling `seek()` before a `read()`.
        * Sometimes the client-code is simpler when reading multiple records
          if it can call `seek()` with an explicit offset before each `read()`.
        * The alternative would be calling `read()` multiple times sequentially
          and using its internal cursor to advance automatically.
        * This benchmark shows that `seek()` causes significant performance
          loss, even if the `seek()` offset is identical to the internal cursor,
          so might be expected to be optimized away.
    * Add notes about [Debugging](README.md#Debugging) tools and options
      under a Unix environment, such as Valgrind.
