### PR TITLE
Added implementation for digitalWrite method

### DIFF
--- a/cores/epoxy/Arduino.cpp
+++ b/cores/epoxy/Arduino.cpp
@@ -21,7 +21,7 @@
 // Arduino methods emulated in Unix
 // -----------------------------------------------------------------------
 
-static uint32_t digitalPinValues = 0;
+static uint32_t digitalReadPinValues = 0;
 static uint32_t digitalWritePinValues = 0;
 
 void yield() {
@@ -49,16 +49,16 @@ uint8_t digitalWriteValue(uint8_t pin) {
 int digitalRead(uint8_t pin) {
   if (pin >= 32) return 0;
 
-  return (digitalPinValues & (((uint32_t)0x1) << pin)) != 0;
+  return (digitalReadPinValues & (((uint32_t)0x1) << pin)) != 0;
 }
 
 void digitalReadValue(uint8_t pin, uint8_t val) {
   if (pin >= 32) return;
 
   if (val == 0) {
-    digitalPinValues &= ~(((uint32_t)0x1) << pin);
+    digitalReadPinValues &= ~(((uint32_t)0x1) << pin);
   } else {
-    digitalPinValues |= ((uint32_t)0x1) << pin;
+    digitalReadPinValues |= ((uint32_t)0x1) << pin;
   }
 }
 

--- a/cores/epoxy/Arduino.cpp
+++ b/cores/epoxy/Arduino.cpp
@@ -22,6 +22,7 @@
 // -----------------------------------------------------------------------
 
 static uint32_t digitalPinValues = 0;
+static uint32_t digitalWritePinValues = 0;
 
 void yield() {
   usleep(1000); // prevents program from consuming 100% CPU
@@ -29,7 +30,21 @@ void yield() {
 
 void pinMode(uint8_t /*pin*/, uint8_t /*mode*/) {}
 
-void digitalWrite(uint8_t /*pin*/, uint8_t /*val*/) {}
+void digitalWrite(uint8_t pin, uint8_t val) {
+  if (pin >= 32) return;
+
+  if (val == 0) {
+    digitalWritePinValues &= ~(((uint32_t)0x1) << pin);
+  } else {
+    digitalWritePinValues |= ((uint32_t)0x1) << pin;
+  }
+}
+
+uint8_t digitalWriteValue(uint8_t pin) {
+  if (pin >= 32) return 0;
+
+  return (digitalWritePinValues & (((uint32_t)0x1) << pin)) != 0;
+}
 
 int digitalRead(uint8_t pin) {
   if (pin >= 32) return 0;

--- a/cores/epoxy/Arduino.h
+++ b/cores/epoxy/Arduino.h
@@ -235,6 +235,18 @@ void analogWrite(uint8_t pin, int val);
  */
 void digitalReadValue(uint8_t pin, uint8_t val);
 
+/**
+ * Check the value that was set by `digitalWrite(pin, val)` by setting the interesting
+ * pin argument, where the return value is either 0 or 1. This may be useful for testing
+ * purposes. This works only if `pin < 32` because the underlying implementation
+ * uses a `uint32_t` for storage. If the `pin` is greater than or equal to 32,
+ * this function will return 0.
+ *
+ * This function is available only on EpoxyDuino. It is not a standard Arduino
+ * function, so it is not available when compiling on actual hardware.
+ */
+uint8_t digitalWriteValue(uint8_t pin);
+
 unsigned long millis();
 unsigned long micros();
 void delay(unsigned long ms);


### PR DESCRIPTION
When unit testing my code, I wanted to know if the digitalWrite methods were called correctly.
So at the end of the tests I checked if certain pins were set by reading with digitalRead.
In the end my tests failed because digitalWrite had no implementation