### PR TITLE
merge 1.3.1 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 1.3.1 (2022-08-13)
     * Add `tone()` and `noTone()` stubs. By @kwisii in
       [PR#69](https://github.com/bxparks/EpoxyDuino/pull/69).
     * Add `uint8_t digitalWriteValue(pin)` which returns the value of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 * Unreleased
-    * Add `tone()` and `noTone()` stubs, @kwisii in
+    * Add `tone()` and `noTone()` stubs. By @kwisii in
       [PR#69](https://github.com/bxparks/EpoxyDuino/pull/69).
+    * Add `uint8_t digitalWriteValue(pin)` which returns the value of the
+      most recent `digitalWrite(pin, val)`. By @kwisii in
+      [PR#68](https://github.com/bxparks/EpoxyDuino/pull/68).
 * 1.3.0 (2022-03-28)
     * Add support for `EXTRA_CPPFLAGS`, similar to `EXTRA_CXXFLAGS`.
     * Add `digitalReadValue(pin, val)` to control the return value of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 * Unreleased
+    * Add `tone()` and `noTone()` stubs, @kwisii in
+      [PR#69](https://github.com/bxparks/EpoxyDuino/pull/69).
 * 1.3.0 (2022-03-28)
     * Add support for `EXTRA_CPPFLAGS`, similar to `EXTRA_CXXFLAGS`.
     * Add `digitalReadValue(pin, val)` to control the return value of

--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ example:
 
 I am not an expert on any of these sanitizers, and I have not enabled them by
 default in the `EpoxyDuino.mk` file. But you have the capability to add them to
-your `Makefile` through the `CXXFLAGS` variable.
+your `Makefile` through the `EXTRA_CXXFLAGS` variable.
 
 Below are some things that I have found useful in my own limited experience.
 
@@ -706,8 +706,8 @@ start:
     * This is not strictly necessary but this will allow Valgrind to print line
       numbers to the source code in the stack trace.
     * Two ways:
-        * Pass the pass through the command line: `$ make CXXFLAGS=-g`
-        * Edit the `Makefile` and add a `CXXFLAGS += -g` directive
+        * Pass the pass through the command line: `$ make EXTRA_CXXFLAGS=-g`
+        * Edit the `Makefile` and add a `EXTRA_CXXFLAGS = -g` directive
           near the top of the file.
 2. Run the program under the `valgrind` program.
     * Valgrind has tons of options and flags. Here are the flags that I use

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The disadvantages are:
   environments (e.g. 16-bit `int` versus 32-bit `int`, or 32-bit `long` versus
   64-bit `long`).
 
-**Version**: 1.3.0 (2022-03.28)
+**Version**: 1.3.1 (2022-08-13)
 
 **Changelog**: See [CHANGELOG.md](CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -1126,30 +1126,30 @@ intended. This limitation may be sufficient for Continuous Integration purposes.
 <a name="SystemRequirements"></a>
 ## System Requirements
 
-This library has Tier 1 support on:
+**Tier 1: Fully Supported**
+
+The following environments are tested on each release of EpoxyDuino.
 
 * Ubuntu 20.04.4 LTS
     * g++ (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
     * clang++ version 10.0.0-4ubuntu1
     * GNU Make 4.2.1
 
-The following environments are Tier 2 because I do not test them often enough:
+**Tier 2: Best Effort**
 
-* Ubuntu 18.04 LTS
-    * g++ (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
-    * clang++ 8.0.0-3~ubuntu18.04.2
-    * clang++ 6.0.0-1ubuntu2
-    * GNU Make 4.1
+The following environments are supported on a best-effort basis because I don't
+test them as often.
+
+* MacOS 11.6.7 (Big Sur)
+    * clang++
+        * Apple clang version 13.0.0 (clang-1300.0.29.30)
+        * Target: x86_64-apple-darwin20.6.0
+    * GNU Make 3.81
+    * (Big Sur is the latest MacOS that I am able to test.)
 * Raspbian GNU/Linux 10 (buster)
     * On Raspberry Pi Model 3B
     * g++ (Raspbian 8.3.0-6+rpi1) 8.3.0
     * GNU Make 4.2.1
-* MacOS 10.14.5 (Mojave)
-    * clang++ Apple LLVM version 10.0.1
-    * GNU Make 3.81
-* MacOS 10.14.6 (Mojave)
-    * Apple clang version 11.0.0 (clang-1100.0.33.17)
-    * GNU Make 3.81
 * FreeBSD 12.2
     * c++: FreeBSD clang version 10.0.1
     * gmake: GNU Make 4.3
@@ -1157,6 +1157,24 @@ The following environments are Tier 2 because I do not test them often enough:
         * You can type `gmake` instead of `make`, or
         * Create a shell alias, or
         * Create a symlink in `~/bin`.
+
+**Tier 3: Should Work**
+
+The following environments are older OS environments which worked with previous
+versions of EpoxyDuino. But I am not able to validate them against the latest
+EpoxyDuino release because I no longer use these older environments.
+
+* Ubuntu 18.04 LTS
+    * g++ (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
+    * clang++ 8.0.0-3~ubuntu18.04.2
+    * clang++ 6.0.0-1ubuntu2
+    * GNU Make 4.1
+* MacOS 10.14.6 (Mojave)
+    * Apple clang version 11.0.0 (clang-1100.0.33.17)
+    * GNU Make 3.81
+* MacOS 10.14.5 (Mojave)
+    * clang++ Apple LLVM version 10.0.1
+    * GNU Make 3.81
 
 <a name="License"></a>
 ## License

--- a/README.md
+++ b/README.md
@@ -1202,3 +1202,5 @@ people ask similar questions later.
 * Add `digitalReadValue(pin, val)` to control the return value of
   `digitalRead(pin)` by @CaioPellicani. See
   [PR#61](https://github.com/bxparks/EpoxyDuino/pull/61).
+* Add `tone()` and `noTone()` stubs, by @kwisii in
+  [PR#69](https://github.com/bxparks/EpoxyDuino/pull/69).

--- a/cores/epoxy/Arduino.cpp
+++ b/cores/epoxy/Arduino.cpp
@@ -21,7 +21,7 @@
 // Arduino methods emulated in Unix
 // -----------------------------------------------------------------------
 
-static uint32_t digitalPinValues = 0;
+static uint32_t digitalReadPinValues = 0;
 static uint32_t digitalWritePinValues = 0;
 
 void yield() {
@@ -49,16 +49,16 @@ uint8_t digitalWriteValue(uint8_t pin) {
 int digitalRead(uint8_t pin) {
   if (pin >= 32) return 0;
 
-  return (digitalPinValues & (((uint32_t)0x1) << pin)) != 0;
+  return (digitalReadPinValues & (((uint32_t)0x1) << pin)) != 0;
 }
 
 void digitalReadValue(uint8_t pin, uint8_t val) {
   if (pin >= 32) return;
 
   if (val == 0) {
-    digitalPinValues &= ~(((uint32_t)0x1) << pin);
+    digitalReadPinValues &= ~(((uint32_t)0x1) << pin);
   } else {
-    digitalPinValues |= ((uint32_t)0x1) << pin;
+    digitalReadPinValues |= ((uint32_t)0x1) << pin;
   }
 }
 

--- a/cores/epoxy/Arduino.cpp
+++ b/cores/epoxy/Arduino.cpp
@@ -22,6 +22,7 @@
 // -----------------------------------------------------------------------
 
 static uint32_t digitalPinValues = 0;
+static uint32_t digitalWritePinValues = 0;
 
 void yield() {
   usleep(1000); // prevents program from consuming 100% CPU
@@ -29,7 +30,21 @@ void yield() {
 
 void pinMode(uint8_t /*pin*/, uint8_t /*mode*/) {}
 
-void digitalWrite(uint8_t /*pin*/, uint8_t /*val*/) {}
+void digitalWrite(uint8_t pin, uint8_t val) {
+  if (pin >= 32) return;
+
+  if (val == 0) {
+    digitalWritePinValues &= ~(((uint32_t)0x1) << pin);
+  } else {
+    digitalWritePinValues |= ((uint32_t)0x1) << pin;
+  }
+}
+
+uint8_t digitalWriteValue(uint8_t pin) {
+  if (pin >= 32) return 0;
+
+  return (digitalWritePinValues & (((uint32_t)0x1) << pin)) != 0;
+}
 
 int digitalRead(uint8_t pin) {
   if (pin >= 32) return 0;

--- a/cores/epoxy/Arduino.h
+++ b/cores/epoxy/Arduino.h
@@ -235,6 +235,18 @@ void analogWrite(uint8_t pin, int val);
  */
 void digitalReadValue(uint8_t pin, uint8_t val);
 
+/**
+ * Check the value that was set by `digitalWrite(pin, val)` by setting the interesting
+ * pin argument, where the return value is either 0 or 1. This may be useful for testing
+ * purposes. This works only if `pin < 32` because the underlying implementation
+ * uses a `uint32_t` for storage. If the `pin` is greater than or equal to 32,
+ * this function will return 0.
+ *
+ * This function is available only on EpoxyDuino. It is not a standard Arduino
+ * function, so it is not available when compiling on actual hardware.
+ */
+uint8_t digitalWriteValue(uint8_t pin);
+
 unsigned long millis();
 unsigned long micros();
 void delay(unsigned long ms);

--- a/cores/epoxy/Arduino.h
+++ b/cores/epoxy/Arduino.h
@@ -14,8 +14,8 @@
 #define EPOXY_DUINO_EPOXY_ARDUINO_H
 
 // xx.yy.zz => xxyyzz (without leading 0)
-#define EPOXY_DUINO_VERSION 10300
-#define EPOXY_DUINO_VERSION_STRING "1.3.0"
+#define EPOXY_DUINO_VERSION 10301
+#define EPOXY_DUINO_VERSION_STRING "1.3.1"
 
 #include <algorithm> // min(), max()
 #include <cmath> // abs()

--- a/examples/StdioSerialEcho/StdioSerialEcho.ino
+++ b/examples/StdioSerialEcho/StdioSerialEcho.ino
@@ -110,5 +110,8 @@ void setup(void) {
 }
 
 void loop(void) {
+  // Choose one of the following loop methods to test Serial.available()
+  // and Serial.read(). Both of them should work:
   loopExplicitly();
+  //loopImplicitly();
 }

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "EpoxyDuino",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Compile and run Arduino programs natively on Linux, MacOS and FreeBSD.",
     "keywords": [
         "unit-test",


### PR DESCRIPTION
* 1.3.1 (2022-08-13)
    * Add `tone()` and `noTone()` stubs. By @kwisii in
      [PR#69](https://github.com/bxparks/EpoxyDuino/pull/69).
    * Add `uint8_t digitalWriteValue(pin)` which returns the value of the
      most recent `digitalWrite(pin, val)`. By @kwisii in
      [PR#68](https://github.com/bxparks/EpoxyDuino/pull/68).
