### PR TITLE
Add ESP8266 basic restart and getChipId functions

### DIFF
--- a/cores/epoxy/Esp.h
+++ b/cores/epoxy/Esp.h
@@ -15,6 +15,8 @@ class EspClass
 
 		void reset() {};
 
+		void restart() {};
+
 		// Very ugly approximation, this is freeStack
 		unsigned long getFreeHeap() {
       int i;
@@ -23,6 +25,8 @@ class EspClass
     }
 
 		uint32_t getCpuFreqMHZ() { return 80; }
+
+		uint32_t getChipId() { return 0; }
 
 		uint32_t getCycleCount() {
 			struct timeval now;


### PR DESCRIPTION
`restart()` matches the existing `reset()` implementation.

`getChipId()` may be debatable. Each ESP8266 should have three unique bytes burned to the chip - `getChipId()` returns these three as decimal. `0` technically is valid to return, but is an unrealistic response. Returning a number like `1193046` (123456 in hex) or `16777215` (FFFFFF in hex) are also unrealistic, but might be more representative of what the function would typically return.