### PR TITLE
merge 1.6.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
     * Add `strncat_P()` to `pgmspace.h`.
     * Add `ESP.restart()` and `ESP.getChipId()`. See
       [PR#84](https://github.com/bxparks/EpoxyDuino/pull/84).
+    * Support files located in the `utility` subdirectory for libraries using
+      the old v1.0 format. Fixes
+      [Issue#89](https://github.com/bxparks/EpoxyDuino/issues/89).
 * 1.5.0 (2022-12-08)
     * Support compiling plain `*.c` files in libraries and in the application.
         * The C files are assumed to be written in C11.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+    * Add `strncat_P()` to `pgmspace.h`.
 * 1.5.0 (2022-12-08)
     * Support compiling plain `*.c` files in libraries and in the application.
         * The C files are assumed to be written in C11.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Unreleased
+* 1.6.0 (2024-07-25)
     * Add `strncat_P()` to `pgmspace.h`.
     * Add `ESP.restart()` and `ESP.getChipId()`. See
       [PR#84](https://github.com/bxparks/EpoxyDuino/pull/84).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Unreleased
     * Add `strncat_P()` to `pgmspace.h`.
+    * Add `ESP.restart()` and `ESP.getChipId()`. See
+      [PR#84](https://github.com/bxparks/EpoxyDuino/pull/84).
 * 1.5.0 (2022-12-08)
     * Support compiling plain `*.c` files in libraries and in the application.
         * The C files are assumed to be written in C11.

--- a/EpoxyDuino.mk
+++ b/EpoxyDuino.mk
@@ -152,10 +152,12 @@ CPPFLAGS += $(EXTRA_CPPFLAGS)
 CPPFLAGS += -D ARDUINO=100 -D UNIX_HOST_DUINO -D EPOXY_DUINO -D $(EPOXY_CORE)
 # Add the header files for the Core files.
 CPPFLAGS += -I$(EPOXY_CORE_PATH)
-# Add the header files for libraries. Old Arduino libraries place the header
-# and source files right at the top. New Arduino libraries tend to use the
-# ./src/ subdirectory. We need to support both.
-CPPFLAGS_EXPANSION = -I$(module) -I$(module)/src
+# Add the header files for libraries. Old Arduino libraries (v1.0) place the
+# header and source files right at the top, or in a subdirectory named
+# 'utility'. New Arduino libraries (v1.5) place all their files recursively
+# under the ./src/ subdirectory. We need to support both. See details at:
+# https://arduino.github.io/arduino-cli/1.0/library-specification/ .
+CPPFLAGS_EXPANSION = -I$(module) -I$(module)/src -I$(module)/utility
 CPPFLAGS += $(foreach module,$(EPOXY_MODULES),$(CPPFLAGS_EXPANSION))
 
 # Linker settings (e.g. -lm).
@@ -176,11 +178,13 @@ EPOXY_SRCS := $(wildcard $(EPOXY_CORE_PATH)/*.cpp) \
 # Later Arduino libraries put the source files under the src/ directory. Also
 # support 3 levels of subdirectories. Support both C and C++ libraries files.
 MODULE_EXPANSION_CPP = $(wildcard $(module)/*.cpp) \
+	$(wildcard $(module)/utility/*.cpp) \
 	$(wildcard $(module)/src/*.cpp) \
 	$(wildcard $(module)/src/*/*.cpp) \
 	$(wildcard $(module)/src/*/*/*.cpp) \
 	$(wildcard $(module)/src/*/*/*/*.cpp)
 MODULE_EXPANSION_C = $(wildcard $(module)/*.c) \
+	$(wildcard $(module)/utility/*.c) \
 	$(wildcard $(module)/src/*.c) \
 	$(wildcard $(module)/src/*/*.c) \
 	$(wildcard $(module)/src/*/*/*.c) \

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The disadvantages are:
   environments (e.g. 16-bit `int` versus 32-bit `int`, or 32-bit `long` versus
   64-bit `long`).
 
-**Version**: 1.5.0 (2022-12-08)
+**Version**: 1.6.0 (2024-07-25)
 
 **Changelog**: See [CHANGELOG.md](CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -1365,3 +1365,5 @@ people ask similar questions later.
   [PR#68](https://github.com/bxparks/EpoxyDuino/pull/68).
 * Add `memcmp_P()` by @dawidchyrzynski in
   [PR#71](https://github.com/bxparks/EpoxyDuino/pull/71).
+* Add additional ESP functions by @EricLauber in
+  [PR#71](https://github.com/bxparks/EpoxyDuino/pull/84).

--- a/README.md
+++ b/README.md
@@ -1311,6 +1311,16 @@ EpoxyDuino release because I no longer use these older environments.
     * I am not sure that I have migrated all the relevant and important compiler
       flags from the microcontroller environment (AVR, ESP8266, etc.) to
       the EpoxyDuino environment.
+* The `sizeof(int)` is `4` on EpoxyDuino as defined by C++ compilers on
+  Unix environments.
+    * This may cause problems with non-portable Arduino code that assumes that
+      `sizeof(int) == 2` which is true only on 8-bit AVR processors used by
+      older Arduino boards. All other Arduino-compatible microcontrollers (e.g.
+      ESP8266, ESP32, SAMD21, SAMD51) use 32-bit processors whose C++ compilers
+      define `sizeof(int) == 4`.
+    * Non-portable code can be converted into portable code by changing the
+      `short`, `int`, and `long` types into types with explicit sizes such as
+      `int16_t`, `uint16_t`, `int32_t`, `uint32_t`, and so on.
 
 <a name="FeedbackAndSupport"></a>
 ## Feedback and Support

--- a/cores/epoxy/Arduino.h
+++ b/cores/epoxy/Arduino.h
@@ -14,8 +14,8 @@
 #define EPOXY_DUINO_EPOXY_ARDUINO_H
 
 // xx.yy.zz => xxyyzz (without leading 0)
-#define EPOXY_DUINO_VERSION 10500
-#define EPOXY_DUINO_VERSION_STRING "1.5.0"
+#define EPOXY_DUINO_VERSION 10600
+#define EPOXY_DUINO_VERSION_STRING "1.6.0"
 
 #include <algorithm> // min(), max()
 #include <cmath> // abs()

--- a/cores/epoxy/Esp.h
+++ b/cores/epoxy/Esp.h
@@ -8,35 +8,35 @@
 
 class EspClass
 {
-	public:
-		EspClass() {
+  public:
+    EspClass() {
       gettimeofday(&start, NULL);
     }
 
-		void reset() {};
+    void reset() {}
 
-		void restart() {};
+    void restart() {}
 
-		// Very ugly approximation, this is freeStack
-		unsigned long getFreeHeap() {
+    // Very ugly approximation, this is freeStack
+    unsigned long getFreeHeap() {
       int i;
       static int* h=40000+&i;
       return h-&i;
     }
 
-		uint32_t getCpuFreqMHZ() { return 80; }
+    uint32_t getCpuFreqMHZ() { return 80; }
 
-		uint32_t getChipId() { return 0; }
+    uint32_t getChipId() { return 0; }
 
-		uint32_t getCycleCount() {
-			struct timeval now;
-			gettimeofday(&now, NULL);
-			return getCpuFreqMHZ()
+    uint32_t getCycleCount() {
+      struct timeval now;
+      gettimeofday(&now, NULL);
+      return getCpuFreqMHZ()
           * ((now.tv_sec-start.tv_sec)*1000000+(now.tv_usec-start.tv_usec));
-		}
+    }
 
-	private:
-		struct timeval start;
+  private:
+    struct timeval start;
 };
 
 class Serial_ : public Stream

--- a/cores/epoxy/pgmspace.h
+++ b/cores/epoxy/pgmspace.h
@@ -39,20 +39,21 @@
 #define pgm_read_float_far(addr)  pgm_read_float(addr)
 #define pgm_read_ptr_far(addr)    pgm_read_ptr(addr)
 
-#define strlen_P strlen
-#define strcat_P strcat
-#define strcpy_P strcpy
-#define strncpy_P strncpy
-#define strcmp_P strcmp
-#define strncmp_P strncmp
+#define memcmp_P memcmp
+#define memcpy_P memcpy
+#define snprintf_P snprintf
 #define strcasecmp_P strcasecmp
-#define strncasecmp_P strncasecmp
+#define strcat_P strcat
 #define strchr_P strchr
+#define strcmp_P strcmp
+#define strcpy_P strcpy
+#define strlen_P strlen
+#define strncasecmp_P strncasecmp
+#define strncat_P strncat
+#define strncmp_P strncmp
+#define strncpy_P strncpy
 #define strrchr_P strrchr
 #define strstr_P strstr
-#define memcpy_P memcpy
-#define memcmp_P memcmp
-#define snprintf_P snprintf
 #define vsnprintf_P vsnprintf
 
 #endif

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "EpoxyDuino",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "Compile and run Arduino programs natively on Linux, MacOS and FreeBSD.",
     "keywords": [
         "unit-test",


### PR DESCRIPTION
* 1.6.0 (2024-07-25)
    * Add `strncat_P()` to `pgmspace.h`.
    * Add `ESP.restart()` and `ESP.getChipId()`. See
      [PR#84](https://github.com/bxparks/EpoxyDuino/pull/84).
    * Support files located in the `utility` subdirectory for libraries using
      the old v1.0 format. Fixes
      [Issue#89](https://github.com/bxparks/EpoxyDuino/issues/89).
